### PR TITLE
Update to allow MOM6 checkout

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -127,18 +127,17 @@ set usemodules = 0
 #========#
 if ( $site == NCCS ) then
 
-   set mod1 = GEOSenv
+   set mod1 = other/comp/gcc-6.3
+   set mod2 = comp/intel-18.0.3.222
 
-   set mod2 = other/comp/gcc-6.3
-   set mod3 = comp/intel-18.0.3.222
+   set mod3 = mpi/sgi-mpt-2.17
 
-   set mod4 = mpi/sgi-mpt-2.17
-
-   set mod5 = lib/mkl-18.0.3.222
-   set mod6 = other/SIVO-PyD/spd_1.25.1_gcc-6.3_mkl-17.0.4.196
+   set mod4 = lib/mkl-18.0.3.222
+   set mod5 = other/SIVO-PyD/spd_1.25.1_gcc-6.3_mkl-17.0.4.196
 
    set basedir = /discover/swdev/mathomp4/Baselibs/ESMA-Baselibs-5.1.7/x86_64-unknown-linux-gnu/ifort_18.0.3.222-mpt_2.17
-   #set mod7 = Baselibs/ifort_18.0.3-intelmpi_18.0.3/5.1.7
+
+   set mod6 = GEOSenv
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
    set modinit = /usr/share/modules/init/csh


### PR DESCRIPTION
It turns out the MOM6 external uses https submodules. Unfortunately, SIVO-PyD carries a libcurl that doesn't have https support or something. But, if we load GEOSpyD *after* SIVO-PyD it then wins. Not perfect, but the simplest fix until we can move to GEOSpyD