### PR TITLE
Move MAPL 2.0 to use Baselibs 6.0.4

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -137,7 +137,7 @@ if ( $site == NCCS ) then
    set mod5 = lib/mkl-18.0.5.274
    set mod6 = other/python/GEOSpyD/Ana2019.03_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.3-SLES11/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_18.0.5.274
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4-SLES11/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_18.0.5.274
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
    set modinit = /usr/share/modules/init/csh
@@ -152,7 +152,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.3/x86_64-unknown-linux-gnu/ifort_2019.3.199-mpt_2.17r13-gcc_6.3.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4/x86_64-unknown-linux-gnu/ifort_2019.3.199-mpt_2.17r13-gcc_6.3.0
 
    set mod1 = GEOSenv
 
@@ -176,7 +176,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.3/x86_64-unknown-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4/x86_64-unknown-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -230,7 +230,7 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.3/x86_64-unknown-linux-gnu/ifort_18.0.5.274-openmpi_4.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4/x86_64-unknown-linux-gnu/ifort_18.0.5.274-openmpi_4.0.0-gcc_6.3.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This should allow GNU MAPL CMake tests to work again due to the update
to pFUnit 4.1.5.

Seems zero-diff in my testing with GCC and Intel.