### PR TITLE
Fixes #33. Update to Intel MPI 19.1

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -135,11 +135,11 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/6.5.0
       set mod3 = comp/intel/18.0.5.274
 
-      set mod4 = mpi/impi/18.0.5.274
+      set mod4 = mpi/impi/19.1.0.166
 
       set mod5 = python/GEOSpyD/Ana2019.10_py2.7
 
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4-SLES12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_18.0.5.274
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.4-SLES12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_19.1.0.166
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
 


### PR DESCRIPTION
This moves GEOS to use Intel MPI 19.1 on SLES12. @weiyuan-jiang was having issues running GEOSldas with Intel MPI 18 and NCCS recommended moving up.