### PR TITLE
Update to Baselibs 6.0.13

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -139,7 +139,7 @@ if ( $site == NCCS ) then
 
       set mod5 = python/GEOSpyD/Ana2019.10_py2.7
 
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.12-SLES12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_19.1.0.166
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.13-SLES12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_19.1.0.166
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
 
@@ -158,7 +158,7 @@ if ( $site == NCCS ) then
       set mod5 = lib/mkl-18.0.5.274
       set mod6 = other/python/GEOSpyD/Ana2019.10_py2.7
 
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.12-SLES11/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_18.0.5.274
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.13-SLES11/x86_64-unknown-linux-gnu/ifort_18.0.5.274-intelmpi_18.0.5.274
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
 
@@ -177,7 +177,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.12/x86_64-unknown-linux-gnu/ifort_2018.5.274-mpt_2.17r13-gcc_6.3.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.13/x86_64-unknown-linux-gnu/ifort_2018.5.274-mpt_2.17r13-gcc_6.3.0
 
    set mod1 = GEOSenv
 
@@ -201,7 +201,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.12/x86_64-unknown-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.13/x86_64-unknown-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -255,7 +255,7 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.12/x86_64-unknown-linux-gnu/ifort_18.0.5.274-openmpi_4.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.13/x86_64-unknown-linux-gnu/ifort_18.0.5.274-openmpi_4.0.0-gcc_6.3.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This update moves to Baselibs 6.0.13 (changes below). The main changes are moving to ESMF 8.0.1 stable and to a version of yaFyaml that has `-fPIC` enabled (needed for MOM6 and JEDI).

Testing says it is zero-diff.

### Updates

* ESMF 8.0.1
* gFTL-shared v1.0.7
* pFUnit v4.1.7
* pFlogger v1.4.2
* fArgParse v0.9.5
* yaFyaml v0.3.3

### Fixed

* Fixes for GCC 10
  * Added patch for netcdf issue with GCC 10
  * Added flag for HDF4 when using GCC 10
  * Need to pass in extra flags to ESMF when using GCC 10
* Fix for detection for `--enable-dap` with netcdf
