### PR TITLE
Reduce number of jobs in make step at NCCS and NAS

### DIFF
--- a/build.csh
+++ b/build.csh
@@ -407,7 +407,15 @@ if ( ($SITE == NCCS) || ($SITE == NAS) ) then
    # use set number of CPUs on NCCS or NAS
    #--------------------------------------
    @ ncpus_val  = $NCPUS_DFLT
-   @ numjobs_val  = $ncpus_val / 2  # save some CPUs for memory
+   @ numjobs_val  = $ncpus_val / 3  # save some CPUs for memory
+
+   # use only even number of CPUs
+   #-----------------------------
+   @ check = ( $numjobs_val % 2 )
+   if ($check == 1) then
+      @ numjobs_val --
+      echo "Rounding down to an even $numjobs_val CPUs."
+   endif
 
    # Are we on a compute node?
    # -------------------------

--- a/build.csh
+++ b/build.csh
@@ -407,7 +407,7 @@ if ( ($SITE == NCCS) || ($SITE == NAS) ) then
    # use set number of CPUs on NCCS or NAS
    #--------------------------------------
    @ ncpus_val  = $NCPUS_DFLT
-   @ numjobs_val  = $ncpus_val - 2  # save some CPUs for memory
+   @ numjobs_val  = $ncpus_val / 2  # save some CPUs for memory
 
    # Are we on a compute node?
    # -------------------------


### PR DESCRIPTION
There seem to be oddities in the current GEOS make environment. One possible thought is that running, say, `make -j26 install` is just a waste. Even if you have 28 cores available, GEOS can't really gain much beyond `-j8`, `-j12`. So, instead of using two less than the number of cores, we use a third of the cores. 