### PR TITLE
Changes needed to allow use of aggressive flags with GEOS

### DIFF
--- a/build.csh
+++ b/build.csh
@@ -780,7 +780,6 @@ flagged options
 
    -develop             checkout with GEOSgcm_GridComp and GEOSgcm_App develop branches
    -debug (or -db)      compile with debug flags (-DCMAKE_BUILD_TYPE=Debug)
-   -aggressive          compile with aggressive flags (-DCMAKE_BUILD_TYPE=Aggressive)
    -builddir dir        alternate CMake build directory (relative to $ESMADIR)
    -installdir dir      alternate CMake install directory (relative to $ESMADIR)
    -tmpdir dir          alternate Fortran TMPDIR location

--- a/build.csh
+++ b/build.csh
@@ -360,6 +360,7 @@ if ($ddb) then
    echo "prompt = $prompt"
    echo "nocmake = $docmake"
    echo "NCPUS_DFLT = $NCPUS_DFLT"
+   echo "CMAKE_BUILD_TYPE= $cmake_build_type"
    echo "Build directory = $Pbuild_build_directory"
    echo "Install directory = $Pbuild_install_directory"
    exit

--- a/build.csh
+++ b/build.csh
@@ -358,7 +358,7 @@ if ($ddb) then
    echo "account = $account"
    echo "walltime = $walltime"
    echo "prompt = $prompt"
-   echo "nocmake = $nocmake"
+   echo "nocmake = $docmake"
    echo "NCPUS_DFLT = $NCPUS_DFLT"
    echo "Build directory = $Pbuild_build_directory"
    echo "Install directory = $Pbuild_install_directory"

--- a/build.csh
+++ b/build.csh
@@ -360,7 +360,7 @@ if ($ddb) then
    echo "prompt = $prompt"
    echo "nocmake = $docmake"
    echo "NCPUS_DFLT = $NCPUS_DFLT"
-   echo "CMAKE_BUILD_TYPE= $cmake_build_type"
+   echo "CMAKE_BUILD_TYPE = $cmake_build_type"
    echo "Build directory = $Pbuild_build_directory"
    echo "Install directory = $Pbuild_install_directory"
    exit

--- a/build.csh
+++ b/build.csh
@@ -229,7 +229,7 @@ end
 # Only allow one of debug and aggressive
 # --------------------------------------
 
-if ( ($aggressive) && ($debug) )
+if ( ($aggressive) && ($debug) ) then
    echo "ERROR. Only one of -debug and -aggressive is allowed"
    exit 1
 endif


### PR DESCRIPTION
This adds a "hidden" option `-aggressive` to use the new `Aggressive` `CMAKE_BUILD_TYPE`. It's "hidden" in that the usage statement doesn't mention it. This is done because the side-effects of the `Aggressive` can be unanticipated to the uninformed user.