### PR TITLE
Update to Baselibs 6.0.27

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -136,7 +136,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.22/x86_64-pc-linux-gnu/ifort_19.1.3.304-intelmpi_19.1.3.304
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_19.1.3.304-intelmpi_19.1.3.304
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -151,7 +151,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.22/x86_64-pc-linux-gnu/ifort_2020.4.304-mpt_2.23-gcc_8.4.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_2020.4.304-mpt_2.23-gcc_8.4.0
 
    set mod1 = GEOSenv
 
@@ -174,7 +174,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.22/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -228,7 +228,7 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.22/x86_64-pc-linux-gnu/ifort_19.1.3.304-openmpi_4.0.5-gcc_8.2.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_19.1.3.304-openmpi_4.0.5-gcc_8.2.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates to Baselibs 6.0.27 which is a minor update to the current 6.0.22. The differences were mainly in the build system, though an important update is the yaFyaml for some work being done in MAPL.

## [6.0.27] - 2020-12-21

### Fixed

- Use of ifort at NAS was broken by changes to make the GNU Make
  system more robust
- HDF5 at NCCS with MPT requires an extra flag to compile

## [6.0.26] - 2020-12-09

### Updates

* cURL 7.74.0
* yaFyaml v0.4.2

### Fixed

* Fixes for GitHub Actions

## [6.0.25] - 2020-12-08

### Updates

* NCO 4.9.6

### Fixed

* Add patch for using antlr2 GitHub as it seems to have a bug. The patch
  makes it match the previous tarball

### Changed

* Moved to use antlr2 from https://github.com/nco/antlr2 as the download
  link broke
* Disabled the Java, Python, and C# builds for antlr2 as unneeded for
  NCO/ncap2

## [6.0.24] - 2020-11-25

### Fixed

- Explicitly turn off nghttp2 and nghttp3 support in cURL. It can
  sometimes find it in a Brew installation, but that could lead to
  linking in Brew includes and libraries.
- Fixed bug with using clang as C compiler
- Updated GitHub Actions workflow with new build image and fixed issues
  with build

### Changed

- Turned off default ESMPy build on Darwin with `esmf.install` due to
  odd RPATH issues. ESMPy can be built separately if needed.

## [6.0.23] - 2020-11-25

### Fixed

- GNU Make system reworked to be more generic. Older system assumed
  modules, `CC`, `FC`, etc were defined like at NCCS
