### PR TITLE
Move to Baselibs 6.1.0

### DIFF
--- a/g5_modules
+++ b/g5_modules
@@ -136,7 +136,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_19.1.3.304-intelmpi_19.1.3.304
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.1.0/x86_64-pc-linux-gnu/ifort_19.1.3.304-intelmpi_19.1.3.304
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -151,7 +151,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_2020.4.304-mpt_2.23-gcc_8.4.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.1.0/x86_64-pc-linux-gnu/ifort_2020.4.304-mpt_2.23-gcc_8.4.0
 
    set mod1 = GEOSenv
 
@@ -174,7 +174,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.1.0/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -228,7 +228,7 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.0.27/x86_64-pc-linux-gnu/ifort_19.1.3.304-openmpi_4.0.5-gcc_8.2.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.1.0/x86_64-pc-linux-gnu/ifort_19.1.3.304-openmpi_4.0.5-gcc_8.2.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This moves GEOS to use ESMF 8.1.0.

All testing shows this to be zero-diff to Baselibs 6.0.27, though this cannot be guaranteed for runs at very high resolution (maybe).