### PR TITLE
Use MPT 2.25 at NAS on TOSS nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.6.0] - 2021-Nov-03
+
+### Changes
+
+- Per NAS advice, use MPT 2.25 on TOSS nodes
+
 ## [3.5.1] - 2021-Nov-03
 
 ### Fixed

--- a/g5_modules
+++ b/g5_modules
@@ -166,11 +166,11 @@ if ( $site == NCCS ) then
 else if ( $site == NAS ) then
 
    if ( $nasos == TOSS3 ) then
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.2.0-mpt_2.23-TOSS3
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.2.0-mpt_2.25-TOSS3
    else if ( $nasos == SLES15 ) then
       set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.2.0-mpt_2.23-ROME-SLES15
    else
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.2.0-mpt_2.23
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.2.0-mpt_2.23-SLES12
    endif
 
    set mod1 = GEOSenv
@@ -181,7 +181,11 @@ else if ( $site == NAS ) then
       set mod2 = comp-gcc/10.2.0
    endif
    set mod3 = comp-intel/2021.2.0
-   set mod4 = mpi-hpe/mpt.2.23
+   if ( $nasos == TOSS3 ) then
+      set mod4 = mpi-hpe/mpt.2.25
+   else
+      set mod4 = mpi-hpe/mpt.2.23
+   endif
    set mod5 = python/GEOSpyD/Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )


### PR DESCRIPTION
Per NAS advice, use MPT 2.25 on TOSS nodes.