### PR TITLE
Add -no-tar option to build.csh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+- Add `build.csh` option `-notar` to turn off source tarfile generation (aka run CMake with `-DINSTALL_SOURCE_TARFILE=OFF`)
+
 ## [3.6.0] - 2021-Nov-03
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-- Add `build.csh` option `-notar` to turn off source tarfile generation (aka run CMake with `-DINSTALL_SOURCE_TARFILE=OFF`)
+- Add `build.csh` option `-no-tar` to turn off source tarfile generation (aka run CMake with `-DINSTALL_SOURCE_TARFILE=OFF`)
 
 ## [3.6.0] - 2021-Nov-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.7.0] - 2021-Dec-06
+
+### Added
+
 - Add `build.csh` option `-no-tar` to turn off source tarfile generation (aka run CMake with `-DINSTALL_SOURCE_TARFILE=OFF`)
 
 ## [3.6.0] - 2021-Nov-03

--- a/build.csh
+++ b/build.csh
@@ -402,6 +402,7 @@ if ($ddb) then
    echo "walltime = $walltime"
    echo "prompt = $prompt"
    echo "nocmake = $docmake"
+   echo "notar = $notar"
    echo "NCPUS_DFLT = $NCPUS_DFLT"
    echo "CMAKE_BUILD_TYPE = $cmake_build_type"
    echo "Build directory = $Pbuild_build_directory"
@@ -808,7 +809,7 @@ else
    setenv INSTALL_SOURCE_TARFILE "ON"
 endif
 
-set cmd1 = "cmake $ESMADIR -DCMAKE_INSTALL_PREFIX=$Pbuild_install_directory -DBASEDIR=${BASEDIR}/${ARCH} -DCMAKE_Fortran_COMPILER=${FORTRAN_COMPILER} -DCMAKE_BUILD_TYPE=${cmake_build_type} ${HYDROBUILD} -DINSTALL_SOURCE_TARFILE=ON"
+set cmd1 = "cmake $ESMADIR -DCMAKE_INSTALL_PREFIX=$Pbuild_install_directory -DBASEDIR=${BASEDIR}/${ARCH} -DCMAKE_Fortran_COMPILER=${FORTRAN_COMPILER} -DCMAKE_BUILD_TYPE=${cmake_build_type} ${HYDROBUILD} -DINSTALL_SOURCE_TARFILE=${INSTALL_SOURCE_TARFILE}"
 set cmd2 = "make --jobs=$numjobs install $verbose"
 echo1 "" 
 echo1 ""

--- a/build.csh
+++ b/build.csh
@@ -73,6 +73,7 @@ endif
 setenv esmadir     ""
 setenv docmake     1
 setenv usegnu      0
+setenv notar       0
 setenv usehydro    0
 setenv usenonhydro 0
 setenv ddb         0
@@ -225,6 +226,12 @@ while ($#argv)
    #---------------
    if ("$1" == "-gnu") then
       setenv usegnu 1
+   endif
+
+   # set no tar option
+   #------------------
+   if ("$1" == "-notar") then
+      setenv notar 1
    endif
 
    # set hydrostatic option
@@ -795,6 +802,12 @@ else
    setenv HYDROBUILD ''
 endif
 
+if ($notar) then
+   setenv INSTALL_SOURCE_TARFILE "OFF"
+else
+   setenv INSTALL_SOURCE_TARFILE "ON"
+endif
+
 set cmd1 = "cmake $ESMADIR -DCMAKE_INSTALL_PREFIX=$Pbuild_install_directory -DBASEDIR=${BASEDIR}/${ARCH} -DCMAKE_Fortran_COMPILER=${FORTRAN_COMPILER} -DCMAKE_BUILD_TYPE=${cmake_build_type} ${HYDROBUILD} -DINSTALL_SOURCE_TARFILE=ON"
 set cmd2 = "make --jobs=$numjobs install $verbose"
 echo1 "" 
@@ -848,6 +861,7 @@ flagged options
    -esmadir dir         esmadir location
    -nocmake             do not run cmake (useful for scripting)
    -gnu                 build with gfortran
+   -notar               build with INSTALL_SOURCE_TARFILE=OFF (does not tar up source tarball, default is ON)
 
    -hydrostatic         build for hydrostatic dynamics in FV
    -nonhydrostatic      build for nonhydrostatic dynamics in FV

--- a/build.csh
+++ b/build.csh
@@ -230,7 +230,7 @@ while ($#argv)
 
    # set no tar option
    #------------------
-   if ("$1" == "-notar") then
+   if ("$1" == "-no-tar") then
       setenv notar 1
    endif
 
@@ -862,7 +862,7 @@ flagged options
    -esmadir dir         esmadir location
    -nocmake             do not run cmake (useful for scripting)
    -gnu                 build with gfortran
-   -notar               build with INSTALL_SOURCE_TARFILE=OFF (does not tar up source tarball, default is ON)
+   -no-tar              build with INSTALL_SOURCE_TARFILE=OFF (does not tar up source tarball, default is ON)
 
    -hydrostatic         build for hydrostatic dynamics in FV
    -nonhydrostatic      build for nonhydrostatic dynamics in FV


### PR DESCRIPTION
This PR adds a new `-no-tar` option to `build.csh` (and thus `parallel_build.csh`) so a user can not tar the source. This is equivalent to building with CMake and `-DINSTALL_SOURCE_TARFILE=OFF`