### PR TITLE
Update for NAS Rome Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.9.0] - 2021-Dec-20
+
+### Changed
+
+- Updated the Rome code in `build.csh` to not use SLES15
+
 ## [3.8.0] - 2021-Dec-16
 
 ### Changed

--- a/build.csh
+++ b/build.csh
@@ -318,7 +318,7 @@ if ( $SITE == NAS ) then
       exit 2
    endif
 
-   if ($nT == rom) set nT = 'rom_ait:aoe=sles15'
+   if ($nT == rom) set nT = 'rom_ait'
    if ($nT == sky) set nT = 'sky_ele'
    if ($nT == cas) set nT = 'cas_ait'
    set proc = ":model=$nT"
@@ -327,7 +327,7 @@ if ( $SITE == NAS ) then
    if ($nT == bro)     @ NCPUS_DFLT = 28
    if ($nT == sky_ele) @ NCPUS_DFLT = 40
    if ($nT == cas_ait) @ NCPUS_DFLT = 40
-   if ($nT == "rom_ait:aoe=sles15") @ NCPUS_DFLT = 128
+   if ($nT == rom_ait) @ NCPUS_DFLT = 128
 
    # TMPDIR needs to be reset
    #-------------------------


### PR DESCRIPTION
The Rome nodes at NAS now are defaulting to TOSS. This update removes the sles15 aoe for PBS.