### PR TITLE
Update to Baselibs 6.2.13, Load Py2 and Py3 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [3.12.0] - 2022-03-09
+
+## Changed
+
+- Update to Baselibs 6.2.13
+- Move to have both Python2 and Python3 loaded at the same time
+
 ## [3.11.0] - 2022-01-24
 
 ### Removed

--- a/g5_modules
+++ b/g5_modules
@@ -136,9 +136,9 @@ if ( $site == NCCS ) then
 
    set mod4 = mpi/impi/2021.3.0
 
-   set mod5 = python/GEOSpyD/Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min4.10.3_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -153,14 +153,14 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25-TOSS3
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
 
    set mod1 = GEOSenv
 
    set mod2 = gcc/10.2
    set mod3 = comp-intel/2021.3.0
    set mod4 = mpi-hpe/mpt.2.25
-   set mod5 = python/GEOSpyD/Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min4.10.3_py3.9_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -176,7 +176,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -230,14 +230,14 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.8/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mod1 = GEOSenv
 
    set mod2 = comp/gcc/10.1.0
    set mod3 = comp/intel/2021.3.0
    set mod4 = mpi/impi/2021.3.0
-   set mod5 = other/python/GEOSpyD/Min4.8.3_py2.7
+   set mod5 = other/python/GEOSpyD/Min4.10.3_py3.9_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
This PR updates the Baselibs to 6.2.13 and also loads a module with *both* Python2 and Python3 at the same time.