### PR TITLE
Update to Baselibs 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.0.0] - 2022-04-21
+
+### Changed
+
+- Update to Baselibs v7.0.0
+  - NOTE: This is a major tick because the yaFyaml in Baselibs 7 is incompatible with code that used yaFyaml in Baselibs 6. This is
+    MAPL for GEOS. Upcoming code changes will require the use of these new yaFyaml interfaces
+
 ## [3.13.0] - 2022-03-17
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -138,7 +138,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.10.3_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.0.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -153,7 +153,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.0.0/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
 
    set mod1 = GEOSenv
 
@@ -176,7 +176,7 @@ else if ( $site == NAS ) then
 #  JANUS  #
 #=========#
 else if ( $site == GMAO.janus ) then
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.0.0/x86_64-pc-linux-gnu/pgfortran_17.10-openmpi_3.0.0-gcc_6.3.0
    set mod1 = comp/gcc/6.3.0
    set mod2 = comp/pgi/17.10-gcc_6.3.0
    set mod3 = mpi/openmpi/3.0.0/pgi-17.10_gcc-6.3.0
@@ -230,7 +230,7 @@ else if ( $site == GMAO.niteroi ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-6.2.13/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.0.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates to Baselibs 7.0.0. Note that yaFyaml in this is incompatible with Baselibs 6, thus the major tick.