### PR TITLE
Update to Baselibs 7.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
-- Added Arm64 section to `g5_modules`
-
 ### Fixed
 ### Removed
 ### Added
+
+## [4.2.0] - 2022-07-01
+
+### Changed
+
+- Moved to Baselibs 7.5.0
+  - Updated
+    - GFE v1.4.0
 
 ## [4.1.0] - 2022-06-15
 

--- a/g5_modules
+++ b/g5_modules
@@ -130,7 +130,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.3.1/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -145,7 +145,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.3.1/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
 
    set mod1 = GEOSenv
 
@@ -169,7 +169,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.3.1/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates the `g5_modules` to use Baselibs 7.5.0. This updates GFE to v1.4.0.

This is a zero-diff update for GEOSgcm.