### PR TITLE
Update to Intel 2022.1 (aka 2021.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
-- Update to Intel 2022.1
-
 ### Fixed
 ### Removed
 ### Added
+
+## [4.3.0] - 2022-08-19
+
+### Changed
+
+- Update to Intel 2022.1
 
 ## [4.2.0] - 2022-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Update to Intel 2022.1
+
 ### Fixed
 ### Removed
 ### Added

--- a/g5_modules
+++ b/g5_modules
@@ -123,14 +123,14 @@ if ( $site == NCCS ) then
 
    set mod1 = GEOSenv
 
-   set mod2 = comp/gcc/10.1.0
-   set mod3 = comp/intel/2021.3.0
+   set mod2 = comp/gcc/10.3.0
+   set mod3 = comp/intel/2021.6.0
 
-   set mod4 = mpi/impi/2021.3.0
+   set mod4 = mpi/impi/2021.6.0
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -145,12 +145,11 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-mpt_2.25
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
 
    set mod1 = GEOSenv
-
    set mod2 = gcc/10.2
-   set mod3 = comp-intel/2021.3.0
+   set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt.2.25
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
@@ -169,13 +168,13 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.3.0-intelmpi_2021.3.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 
-   set mod2 = comp/gcc/10.1.0
-   set mod3 = comp/intel/2021.3.0
-   set mod4 = mpi/impi/2021.3.0
+   set mod2 = comp/gcc/11.2.0
+   set mod3 = comp/intel/2022.1.0
+   set mod4 = mpi/impi/2022.1.0
    set mod5 = other/python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )


### PR DESCRIPTION
This PR updates the compiler for GEOS to be Intel 2022.1.

This is also known as Intel 2021.6 depending on how it is numbered by the computing center.

All testing shows this is zero-diff and development by @aoloso and @darianboggs have shown Intel 2022.1 has fixes for issues seen in OpenMP work.

---

This checklist will 

- [x] Tested at NCCS
  - [x] Zero-diff
- [x] Tested at NAS
  - [x] Zero-diff
- [x] Tested on Anvil
  - [x] Zero-diff