### PR TITLE
Add TOSS4 Support at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.4.0] - 2022-08-26
+
+### Added
+
+- Add support for TOSS4 at NAS in `g5_modules`
+
 ## [4.3.0] - 2022-08-19
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -81,6 +81,14 @@ else if (($node =~ pfe*) || ($node =~ tfe*) || \
    # We are on NAS...
    set site = "NAS"
 
+   # Are we on TOSS4
+   set LSB_RELEASE = `lsb_release -sr | cut -d'.' -f 1`
+   if ($LSB_RELEASE == '8') then
+      set nasos = "TOSS4"
+   else
+      set nasos = "TOSS3"
+   endif
+
 else if ( -d /ford1/share/gmao_SIteam/ && -d /ford1/local/ && $arch == Linux ) then
    set site = "GMAO.desktop"
 
@@ -145,7 +153,11 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
+   if ( $nasos == TOSS3 ) then
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
+   else
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25-TOSS4-BuiltOnRome
+   endif
 
    set mod1 = GEOSenv
    set mod2 = gcc/10.2


### PR DESCRIPTION
NAS is soon to [move to TOSS4 on its Rome nodes](https://www.nas.nasa.gov/hecc/support/kb/news/help-us-test-rome-nodes-on-toss-4_662.html) (at least???). 

Testing has shown that Baselibs needs rebuilding on TOSS4, so this PR adds the support for that.

Testing shows it is zero-diff when running Rome on TOSS3 vs Rome on TOSS4.