### PR TITLE
Move to Baselibs 7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.7.0] - 2022-11-09
+
+### Changed
+
+- Moved to Baselibs 7.6.0
+  - Updated
+    - ESMF v8.4.0
+    - zlib 1.2.13
+    - curl 7.86.0
+    - netCDF-C 4.9.0
+    - netCDF-Fortran 4.6.0
+    - NCO 5.1.1
+    - CDO 2.1.0
+
 ## [4.6.0] - 2022-11-02
 
 ### Added

--- a/g5_modules
+++ b/g5_modules
@@ -138,7 +138,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.6.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -154,9 +154,9 @@ if ( $site == NCCS ) then
 else if ( $site == NAS ) then
 
    if ( $nasos == TOSS3 ) then
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.6.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
    else
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25-TOSS4-BuiltOnRome
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.6.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25-TOSS4-BuiltOnRome
    endif
 
    set mod1 = GEOSenv
@@ -180,7 +180,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.5.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.6.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR moves `g5_modules` to use ESMA-Baselibs v7.6.0. All testing shows this is zero-diff to Baselibs 7.5.0

This version of Baselibs had the following updates:

### Updates

- ESMF v8.4.0
- zlib 1.2.13
- curl 7.86.0
- netCDF-C 4.9.0
- netCDF-Fortran 4.6.0
- NCO 5.1.1
- CDO 2.1.0