### PR TITLE
Update to Baselibs 7.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.15.0] - 2023-04-19
+
+### Changed
+
+- Moved to Baselibs 7.12.0
+  - GFE v1.10.0
+  - curl 8.0.1
+  - NCO 5.1.5
+
 ## [4.14.0] - 2023-03-29
 
 ### Removed

--- a/g5_modules
+++ b/g5_modules
@@ -138,7 +138,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.11.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -155,10 +155,10 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
    if ( $nasos == TOSS3 ) then
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.11.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
       set mod2 = comp-gcc/11.2.0-TOSS3
    else
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.11.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25-TOSS4-BuiltOnRome
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25-TOSS4-BuiltOnRome
       set mod2 = comp-gcc/11.2.0-TOSS4
    endif
 
@@ -181,7 +181,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.11.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates to use Baselibs 7.12.0

All testing shows this zero-diff to current `main` of ESMA_env with GEOSgcm.