### PR TITLE
Update to Baselibs 7.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.17.0] - 2023-05-25
+
+### Changed
+
+- Moved to Baselibs 7.13.0
+  - esmf v8.5.0b22
+  - curl 8.1.1
+  - HDF5 1.10.10
+  - netCDF-C 4.9.2
+  - netCDF-Fortran 4.6.1
+  - CDO 2.2.0
+
 ## [4.16.1] - 2023-05-24
 
 ### Fixed

--- a/g5_modules
+++ b/g5_modules
@@ -81,14 +81,6 @@ else if (($node =~ pfe*) || ($node =~ tfe*) || \
    # We are on NAS...
    set site = "NAS"
 
-   # Are we on TOSS4
-   set LSB_RELEASE = `lsb_release -sr | cut -d'.' -f 1`
-   if ($LSB_RELEASE == '8') then
-      set nasos = "TOSS4"
-   else
-      set nasos = "TOSS3"
-   endif
-
 else if ( -d /ford1/share/gmao_SIteam/ && -d /ford1/local/ && $arch == Linux ) then
    set site = "GMAO.desktop"
 
@@ -138,7 +130,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -154,17 +146,11 @@ if ( $site == NCCS ) then
 else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
-   if ( $nasos == TOSS3 ) then
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.25
-      set mod2 = comp-gcc/11.2.0-TOSS3
-      set mod3 = comp-intel/2022.1.0
-      set mod4 = mpi-hpe/mpt.2.25
-   else
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
-      set mod2 = comp-gcc/11.2.0-TOSS4
-      set mod3 = comp-intel/2022.1.0
-      set mod4 = mpi-hpe/mpt
-   endif
+
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set mod2 = comp-gcc/11.2.0-TOSS4
+   set mod3 = comp-intel/2022.1.0
+   set mod4 = mpi-hpe/mpt
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
@@ -183,7 +169,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.12.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates g5_modules to use Baselibs 7.13.0 which has updates to:

- esmf v8.5.0b22
- curl 8.1.1
- HDF5 1.10.10
- netCDF-C 4.9.2
- netCDF-Fortran 4.6.1
- CDO 2.2.0

This is zero diff to 4.16