### PR TITLE
Remove Haswell at NCCS, add any option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.18.0] - 2023-07-10
+
+### Changed
+
+- Removed Haswell as build node option at NCCS (no longer available)
+- Added an "any" option for the build node at NCCS which will submit to any available node type
+
 ## [4.17.0] - 2023-05-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [4.18.0] - 2023-07-10
+## [4.18.0] - 2023-07-13
 
 ### Changed
 


### PR DESCRIPTION
This PR removes the Haswell nodes as a build option with `build.csh` (aka `parallel_build.csh`).

It also adds an `-any` option which builds anywhere at NCCS and is the new default.