### PR TITLE
Update to Baselibs 7.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.19.0] - 2023-07-27
+
+### Changed
+
+- Moved to Baselibs 7.14.0
+  - ESMF v8.5.0
+  - GFE v1.11.0
+    - gFTL-shared v1.6.1
+    - pFUnit v4.7.3
+  - curl 8.2.1
+  - NCO 5.1.7
+  - CDO 2.2.1
+
 ## [4.18.0] - 2023-07-13
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -41,7 +41,7 @@
 #  21Jul2008  Takacs   New modules and BASEDIR on discover after OS upgrade
 #  13Apr2009  Stassi   Updated for pleiades
 #  22Apr2010  Kokron   Updated for Fortuna-2.1 on pleiades
-#  21Jul2011  Kokron   Overlay older MKL module as on discover to gain reproducible results from dgeev in GSI 
+#  21Jul2011  Kokron   Overlay older MKL module as on discover to gain reproducible results from dgeev in GSI
 #  24Aug2012  Stassi   Added sh option to write bash source-able file
 #  03Nov2016  Thompson Remove JIBB
 ########################################################################
@@ -130,7 +130,7 @@ if ( $site == NCCS ) then
 
    set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.14.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
@@ -147,7 +147,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.14.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
@@ -169,7 +169,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.13.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.14.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 
@@ -389,7 +389,7 @@ DESCRIPTION
      add the BASEDIR lib directory to LD_LIBRARY_PATH (if necessary), and will
      load library modules when sourced.
 
-     If the script is called with "basedir", "modules", "modinit", or 
+     If the script is called with "basedir", "modules", "modinit", or
      "loadmodules", then it will echo the values to standard output without
      modifying the environment.
 


### PR DESCRIPTION
This PR updates ESMA_env to use Baselibs 7.14.0:

  - ESMF v8.5.0
  - GFE v1.11.0
    - gFTL-shared v1.6.1
    - pFUnit v4.7.3
  - curl 8.2.1
  - NCO 5.1.7
  - CDO 2.2.1