### PR TITLE
Append SLES version to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.20.2] - 2023-10-23
+
+### Fixed
+
+- Append `-SLES12` or `-SLES15` on the build and install directories at NCCS when using `build.csh` to make it clear to users
+
 ## [4.20.1] - 2023-10-23
 
 ### Fixed

--- a/build.csh
+++ b/build.csh
@@ -401,6 +401,23 @@ else
    setenv Pbuild_install_directory $ESMADIR/install
 endif
 
+# If we are at NCCS, because of the dual OSs, we decorate the build and
+# install directory with the OS name. If we submit to Milan, we will add
+# -SLES15, otherwise -SLES12 to the build and install directories.  But,
+# we only do this if the user has not specified a build directory or
+# install directory
+# ---------------------------------------------------------------------
+
+if ($SITE == NCCS) then
+   if ($nT == mil) then
+      set OS_VERSION = SLES15
+   else
+      set OS_VERSION = SLES12
+   endif
+   if (! $?BUILDDIR) setenv Pbuild_build_directory ${Pbuild_build_directory}-${OS_VERSION}
+   if (! $?INSTALLDIR) setenv Pbuild_install_directory ${Pbuild_install_directory}-${OS_VERSION}
+endif
+
 # developer's debug
 #------------------
 if ($ddb) then


### PR DESCRIPTION
In talking with @sdrabenh we felt we should add `-SLES12` or `-SLES15` depending on where the build was sent. For now, all Milan builds without options would do `build-SLES15` and `install-SLES15` and others will get 12s.