### PR TITLE
Fix OS detection inside SLURM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.20.3] - 2023-10-24
+
+### Fixed
+
+- Fixed issue with OS versioning when inside SLURM (has to be detected differently)
+
 ## [4.20.2] - 2023-10-23
 
 ### Fixed


### PR DESCRIPTION
This script is a nightmare and so is csh. The issue now is that if a user passes in `-mil` we see that on the head node, say, but not on the compute node since the arguments are not passed onto SLURM. So there we need to detect OS version directly.