### PR TITLE
Revert back to Open MPI 4.1.5 with Intel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.22.0] - 2023-11-21
+
+### Changed
+
+- Move back to Open MPI 4.1.5 with Intel on NCCS. This avoids a bug between GEOS' Intel debugging flags and MPI_Init with Open MPI 5.0.0 (see https://github.com/open-mpi/ompi/issues/12113)
+
 ## [4.21.0] - 2023-11-20
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -139,9 +139,9 @@ if ( $site == NCCS ) then
 
       set mod2 = comp/gcc/12.3.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/5.0.0/intel-2021.6.0
+      set mod4 = mpi/openmpi/4.1.5/intel-2021.6.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_5.0.0-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.5-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif


### PR DESCRIPTION
As found by @bena-nasa, the GEOS Intel debugging flags use `-init=snan` and that seems to cause Open MPI 5.0.0 to crash on the call to `MPI_Init` (see https://github.com/open-mpi/ompi/issues/12113). 

So we revert back to Open MPI 4.1.5