### PR TITLE
Updates to move to Intel 2021.11 on SLES15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move to use Intel 2021.10 and Open MPI 4.1.6 on SLES15 at NCCS.
+- Move to use Intel Fortran 2021.11 and Intel MPI 2021.11 on SLES15 at NCCS.
 
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Move to use Intel 2021.10 and Open MPI 4.1.6 on SLES15 at NCCS.
+
 ### Fixed
 ### Removed
 ### Added

--- a/g5_modules
+++ b/g5_modules
@@ -138,10 +138,10 @@ if ( $site == NCCS ) then
    else
 
       set mod2 = comp/gcc/12.3.0
-      set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.5/intel-2021.6.0
+      set mod3 = comp/intel/2023.2.1
+      set mod4 = mpi/openmpi/4.1.6/intel-2023.2.1
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.5-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2023.2.1-openmpi_4.1.6-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif


### PR DESCRIPTION
This PR has updates to move GEOS to use Intel Fortran 2021.11 and Intel MPI 2021.11 on SLES 15 at NCCS.