### PR TITLE
Update to Baselibs 7.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.23.0] - 2023-11-30
+
+### Changed
+
+- Moved to Baselibs 7.16.0
+  - ESMF v8.6.0
+  - NCO 5.1.9
+  - CDO 2.3.0
+- Move to Open MPI 4.1.6 with Intel on SLES 15 at NCCS.
+
 ## [4.22.0] - 2023-11-21
 
 ### Changed
 
-- Move back to Open MPI 4.1.5 with Intel on NCCS. This avoids a bug between GEOS' Intel debugging flags and MPI_Init with Open MPI 5.0.0 (see https://github.com/open-mpi/ompi/issues/12113)
+- Move back to Open MPI 4.1.5 with Intel on SLES 15 on NCCS. This avoids a bug between GEOS' Intel debugging flags and MPI_Init with Open MPI 5.0.0 (see https://github.com/open-mpi/ompi/issues/12113)
 
 ## [4.21.0] - 2023-11-20
 

--- a/g5_modules
+++ b/g5_modules
@@ -132,16 +132,16 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.16.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
       set mod2 = comp/gcc/12.3.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.5/intel-2021.6.0
+      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.5-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.16.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -160,7 +160,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.16.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
@@ -182,7 +182,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.15.1/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.16.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This PR updates GEOS to use Baselibs 7.16.0 which has:

- ESMF v8.6.0
- NCO 5.1.9
- CDO 2.3.0

Also, move to Open MPI 4.1.6 with Intel on SLES 15 at NCCS.

Testing shows this is zero-diff.