### PR TITLE
Update to Intel MPI 2021.10 with Intel Fortran on SLES 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Update to use Intel MPI 2021.10.0 with Intel Fortran 2021.6.0 on SLES 15 at NCCS
+  - NOTE: You should use the PSM3 provider at NCCS. It is currently the only stable provider on the system. This is done by setting `I_MPI_OFI_PROVIDER=psm3` which is done by default for SLES15 in GEOSgcm_App
+
 ### Fixed
 ### Removed
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-
-- Moved to Baselibs 7.17.1
-  - Fix for NAG and ESMF 8.6.0
-- Update to use Intel MPI 2021.10.0 with Intel Fortran 2021.6.0 on SLES 15 at NCCS
-  - NOTE: You should use the PSM3 provider at NCCS. It is currently the only stable provider on the system. This is done by setting `I_MPI_OFI_PROVIDER=psm3` which is done by default for SLES15 in GEOSgcm_App
-- Update `g5_modules` to use GCC 11.4 as the backing C compiler on SLES 15 at NCCS
-  - This was done as it was discovered that xgboost was not building on SLES15 with Intel when using GCC 12. Until xgboost can be
-    updated to a newer version, this is the workaround.
-
 ### Fixed
 ### Removed
 ### Added
+
+## [4.28.0] - 2024-03-06
+
+### Changed
+
+- Update to use Intel MPI 2021.10.0 with Intel Fortran 2021.6.0 on SLES 15 at NCCS
+  - NOTE: You should use the PSM3 provider at NCCS. It is currently the only stable provider on the system with Intel MPI. This is done by setting `I_MPI_OFI_PROVIDER=psm3` which is done by default for SLES15 in GEOSgcm_App with Intel MPI.
 
 ## [4.27.0] - 2024-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+### Fixed
+### Removed
+### Added
+
+## [4.25.0] - 2024-01-17
+
+### Changed
 
 - Moved to Baselibs 7.17.1
   - Fix for NAG and ESMF 8.6.0
@@ -16,10 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `g5_modules` to use GCC 11.4 as the backing C compiler on SLES 15 at NCCS
   - This was done as it was discovered that xgboost was not building on SLES15 with Intel when using GCC 12. Until xgboost can be
     updated to a newer version, this is the workaround.
-
-### Fixed
-### Removed
-### Added
 
 ## [4.24.0] - 2023-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-### Fixed
-### Removed
-### Added
-
-## [4.25.0] - 2024-01-17
-
-### Changed
 
 - Moved to Baselibs 7.17.1
   - Fix for NAG and ESMF 8.6.0
@@ -23,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `g5_modules` to use GCC 11.4 as the backing C compiler on SLES 15 at NCCS
   - This was done as it was discovered that xgboost was not building on SLES15 with Intel when using GCC 12. Until xgboost can be
     updated to a newer version, this is the workaround.
+
+### Fixed
+### Removed
+### Added
 
 ## [4.24.0] - 2023-12-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved to Baselibs 7.17.1
+  - Fix for NAG and ESMF 8.6.0
 - Update to use Intel MPI 2021.10.0 with Intel Fortran 2021.6.0 on SLES 15 at NCCS
   - NOTE: You should use the PSM3 provider at NCCS. It is currently the only stable provider on the system. This is done by setting `I_MPI_OFI_PROVIDER=psm3` which is done by default for SLES15 in GEOSgcm_App
+- Update `g5_modules` to use GCC 11.4 as the backing C compiler on SLES 15 at NCCS
+  - This was done as it was discovered that xgboost was not building on SLES15 with Intel when using GCC 12. Until xgboost can be
+    updated to a newer version, this is the workaround.
 
 ### Fixed
 ### Removed

--- a/g5_modules
+++ b/g5_modules
@@ -139,9 +139,9 @@ if ( $site == NCCS ) then
 
       set mod2 = comp/gcc/12.3.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0
+      set mod4 = mpi/impi/2021.10.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.10.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif

--- a/g5_modules
+++ b/g5_modules
@@ -132,16 +132,16 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
-      set mod2 = comp/gcc/12.3.0
+      set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.10.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.10.0-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.10.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -160,7 +160,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
@@ -182,7 +182,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This updates GEOS when running with Intel Fortran on SLES15 at NCCS to use Intel MPI 2021.10. You should also use `I_MPI_OFI_PROVIDER=psm3` with this in our testing. This is set by default now in `gcm_setup`.

This also updates GEOS to use Baselibs 7.17.1 (fixes for NAG) and moves SLES15 Intel to use GCC 11 instead of GCC 12 for a backing compiler. The reason is that it was found by @FlorianDeconinck that xgboost was not being built with GCC 12 + Intel.

ETA: Blocking this until @atrayano can implement a solid rewrite in MAPL for a tilefile checkpoint issue encountered by myself and @wmputman using Intel MPI. → Update: this fix is in MAPL `develop` and should be in MAPL 2.45
