### PR TITLE
Move to Baselibs 7.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Move to Baselibs 7.18.1
+  - HDF5 1.14.3
+  - curl 8.6.0
+  - zlib 1.3.1
+
 ### Fixed
 ### Removed
 ### Added
-
 
 ## [4.25.1] - 2024-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+### Fixed
+### Removed
+### Added
+
+## [4.26.0] - 2024-02-22
+
+### Changed
 
 - Move to Baselibs 7.18.1
   - HDF5 1.14.3
   - curl 8.6.0
   - zlib 1.3.1
-
-### Fixed
-### Removed
-### Added
 
 ## [4.25.1] - 2024-01-24
 

--- a/g5_modules
+++ b/g5_modules
@@ -132,7 +132,7 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
@@ -141,7 +141,7 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0-gcc-11.4.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -160,7 +160,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
@@ -182,7 +182,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This is a PR to update GEOS to use Baselibs 7.18.1. The main difference is the move to HDF5 1.14.3.

Three tests needed:

- [x] MAPL tests
- [x] GEOSgcm → zero-diff
- [x] GEOSldas → https://github.com/GEOS-ESM/GEOSldas/issues/713

Once I confirm the first two, I'll make a branch in GEOSldas so that @biljanaorescanin can do a test run of GEOSldas to make sure it is okay with HDF5 1.14