### PR TITLE
Use latest GEOSpyD on GMAO desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.27.0] - 2024-03-04
+
+### Changed
+
+- Move to use GEOSpyD Min23.5.2 on GMAO desktops
+
 ## [4.26.0] - 2024-02-22
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -189,7 +189,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/11.2.0
    set mod3 = comp/intel/2022.1.0
    set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
+   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
Testing of MAPL on bucy showed that we need to use GEOSpyD Min23.5.2-0_py3.11 on systems like that.