### PR TITLE
Update to Baselibs 7.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - NCO 5.2.2
   - Various other updates
 
+### Fixed
+
+- Testing on GMAO Desktops showed that `LD_LIBRARY_PATH` could not be altered by
+  `g5_modules`. So this is disabled on GMAO Desktops
+
 ## [4.27.0] - 2024-03-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.28.0] - 2024-04-02
+
+### Changed
+
+- Update to Baselibs 7.23.0
+  - Reverted to HDF5 1.10.11 (odd issues on NCCS machines with HDF5 1.14, investigating)
+  - GFE v1.15.0
+    - gFTL v1.13.0
+    - gFTL-shared v1.8.0
+    - fArgParse v1.7.0
+    - pFUnit v4.9.0
+    - yaFyaml v1.3.0
+    - pFlogger v1.14.0
+  - NCO 5.2.2
+  - Various other updates
+
 ## [4.27.0] - 2024-03-04
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -131,17 +131,17 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0-gcc-11.4.0
+      set mod4 = mpi/openmpi/5.0.2/intel-2021.6.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_5.0.2-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -160,12 +160,12 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87-TOSS4
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min4.11.0_py3.9_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -182,7 +182,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.18.1/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 

--- a/g5_modules
+++ b/g5_modules
@@ -7,7 +7,7 @@
 #    * provide single location for BASEDIR and module values
 #    * initialize the following:
 #      - set BASEDIR
-#      - update LD_LIBRARY_PATH with BASEDIR lib
+#      - update LD_LIBRARY_PATH with BASEDIR lib (if useldlibs is set)
 #      - load library modules
 #    * echo expected BASEDIR and library module values when queried
 #
@@ -116,8 +116,8 @@ X86_64:
 
 set modinit = DUMMY
 
-set loadmodules = 0
 set usemodules = 0
+set useldlibs = 0
 
 #========#
 #  NCCS  #
@@ -148,10 +148,11 @@ if ( $site == NCCS ) then
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/csh
-   set loadmodules = 0
 
    set usemods = ( $usemod1 )
    set usemodules = 1
+
+   set useldlibs = 1
 
 #=======#
 #  NAS  #
@@ -169,13 +170,14 @@ else if ( $site == NAS ) then
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
-   set loadmodules = 0
 
    set usemod1 = /u/scicon/tools/modulefiles
    set usemod2 = /nobackup/gmao_SIteam/modulefiles
    set usemod3 = /nasa/modulefiles/testing
    set usemods = ( $usemod1 $usemod2 $usemod3 )
    set usemodules = 1
+
+   set useldlibs = 1
 
 #=================#
 #  GMAO DESKTOP   #
@@ -193,11 +195,14 @@ else if ( $site == GMAO.desktop ) then
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh
-   set loadmodules = 0
 
    set usemod1 = /ford1/share/gmao_SIteam/modulefiles
    set usemods = ( $usemod1 )
    set usemodules = 1
+
+   # Testing shows adding BASEDIR lib to LD_LIBRARY_PATH
+   # causes issues with the TCL modules on the GMAO machines
+   set useldlibs = 0
 
 endif
 
@@ -214,8 +219,8 @@ ARM64:
 
 set modinit = DUMMY
 
-set loadmodules = 0
 set usemodules = 0
+set useldlibs = 0
 
 goto ACTION
 
@@ -239,11 +244,11 @@ if ( $#argv > 0 ) then
    else if ( $1 == modinit ) then
       echo $modinit
 
-   else if ( $1 == loadmodules ) then
-      echo $loadmodules
-
    else if ( $1 == usemodules ) then
       echo $usemods
+
+   else if ( $1 == useldlibs ) then
+      echo $useldlibs
 
    else if ( $1 == ESMA_FC ) then
       echo $ESMA_FC
@@ -291,29 +296,32 @@ endif
 
 # add BASEDIR lib to LD_LIBRARY_PATH, if not already there
 #---------------------------------------------------------
-if ($?LD_LIBRARY_PATH) then
-   echo $LD_LIBRARY_PATH | grep $BASEDIR/$arch/lib > /dev/null
-   if ($status) then  #  == 1, if not found
-      setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/$arch/lib
+
+if ($useldlibs) then
+   if ($?LD_LIBRARY_PATH) then
+      echo $LD_LIBRARY_PATH | grep $BASEDIR/$arch/lib > /dev/null
+      if ($status) then  #  == 1, if not found
+         setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/$arch/lib
+      endif
+   else
+      setenv LD_LIBRARY_PATH $BASEDIR/$arch/lib
    endif
-else
-   setenv LD_LIBRARY_PATH $BASEDIR/$arch/lib
-endif
 
 # add individual $ld_libraries to LD_LIBRARY_PATH, if not already there
 #----------------------------------------------------------------------
-if ($?ld_libraries) then
-   foreach lib ( $ld_libraries )
-      if ($LD_LIBRARY_PATH !~ *$lib*) then
-         setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$lib
-      endif
-   end
-endif
+   if ($?ld_libraries) then
+      foreach lib ( $ld_libraries )
+         if ($LD_LIBRARY_PATH !~ *$lib*) then
+            setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$lib
+         endif
+      end
+   endif
 
-if ($?LD_LIBRARY64_PATH) then
-   echo $LD_LIBRARY64_PATH | grep $BASEDIR/$arch/lib > /dev/null
-   if ($status) then  #  == 1, if not found
-      setenv LD_LIBRARY64_PATH ${LD_LIBRARY64_PATH}:$BASEDIR/$arch/lib
+   if ($?LD_LIBRARY64_PATH) then
+      echo $LD_LIBRARY64_PATH | grep $BASEDIR/$arch/lib > /dev/null
+      if ($status) then  #  == 1, if not found
+         setenv LD_LIBRARY64_PATH ${LD_LIBRARY64_PATH}:$BASEDIR/$arch/lib
+      endif
    endif
 endif
 
@@ -328,8 +336,6 @@ if (-e $modinit) then
    if (! $wrapper) echo -n " and modules"
    source $modinit
    module purge
-
-   if ($loadmodules) module load modules
 
    if ($usemodules) then
       foreach usemod ( $usemods )
@@ -378,9 +384,6 @@ if ($wrapper) then
          echo 'source '$modinit_sh                       >> $outfil
       endif
       echo 'eval `'$modulecmd sh purge'`'                >> $outfil
-      if ($loadmodules) then
-         echo 'eval `'$modulecmd sh load modules'`'      >> $outfil
-      endif
       foreach mod ($mods)
          echo 'eval `'$modulecmd sh load $mod'`'         >> $outfil
       end
@@ -410,11 +413,8 @@ DESCRIPTION
      load library modules when sourced.
 
      If the script is called with "basedir", "modules", "modinit", or
-     "loadmodules", then it will echo the values to standard output without
+     "useldlibs", then it will echo the values to standard output without
      modifying the environment.
-
-     The "modinit" and "loadmodules" options are primarily for use with
-     the g5_modules_perl_wrapper script.
 
 SYNOPSIS
 
@@ -430,8 +430,8 @@ OPTIONS
      basedir             echo expected value for BASEDIR environment variable
      modules             echo expected list of modules
      modinit             echo location of csh module initialization script
-     loadmodules         echo logical indicating whether "module load modules"
-                              is needed prior to loading other modules
+     useldlibs           echo logical indicating whether BASEDIR lib should be
+                              added to LD_LIBRARY_PATH
      usemodules          echo logical indicating whether "module use directory(s)"
                               is needed prior to loading other modules
      ESMA_FC             echo value of ESMA_FC if set

--- a/g5_modules
+++ b/g5_modules
@@ -189,7 +189,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/11.2.0
    set mod3 = comp/intel/2022.1.0
    set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11
+   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
This PR moves ESMA_env to use Baselibs 7.23.0. The changes from ESMA_env v4.27.0 are:

- Update to Baselibs 7.23.0
  - Reverted to HDF5 1.10.11 (odd issues on NCCS machines with HDF5 1.14, investigating)
  - GFE v1.15.0
    - gFTL v1.13.0
    - gFTL-shared v1.8.0
    - fArgParse v1.7.0
    - pFUnit v4.9.0
    - yaFyaml v1.3.0
    - pFlogger v1.14.0
  - NCO 5.2.2
  - Various other updates

Note that with this update, GCC 13 is now fully supported. But, GCC 12 is not zero-diff to GCC 13.