### PR TITLE
Move back to Open MPI 4 at NCCS on SLES15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [4.29.1] - 2024-04-03
+## [4.28.1] - 2024-04-03
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.29.1] - 2024-04-03
+
+### Fixed
+
+- Move back to Open MPI 4 at NCCS
+  - Testing showed crashes at C360 and under various other circumstances
+
 ## [4.28.0] - 2024-04-02
 
 ### Changed
@@ -27,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - pFlogger v1.14.0
   - NCO 5.2.2
   - Various other updates
+- Move to use Open MPI 5 by default
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Move back to Open MPI 4 at NCCS
+- Move back to Open MPI 4 on SLES15 at NCCS
   - Testing showed crashes at C360 and under various other circumstances
 
 ## [4.28.0] - 2024-04-02
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - pFlogger v1.14.0
   - NCO 5.2.2
   - Various other updates
-- Move to use Open MPI 5 by default
+- Move to use Open MPI 5 by default on SLES15 at NCCS
 
 ### Fixed
 

--- a/g5_modules
+++ b/g5_modules
@@ -139,9 +139,9 @@ if ( $site == NCCS ) then
 
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/5.0.2/intel-2021.6.0
+      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0-gcc-11.4.0
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_5.0.2-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.23.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif


### PR DESCRIPTION
Testing at NCCS showed that, for some reason, Open MPI 5 (which was moved to in 4.28.0) causes crashes with GEOSgcm at c360. Not c48, 90, 180, or 720...just c360. 

But Open MPI 4.1.6 does not have this issue so we revert.