### PR TITLE
Update to GEOSpyD Min24.4.0-0_py3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.1.0] - 2024-06-03
+
+### Changed
+
+- Moved to use GEOSpyD Min24.4.0 Python 3.12 stack
+  - NOTE: This requires using at least ESMA_cmake v3.45.1 due to f2py issues with Python 3.12. However, ESMA_env v5 should be used
+    with ESMA_cmake v4.0.0 due to changes in the CMake build system to support FMS in Baselibs
+
 ## [5.0.0] - 2024-05-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved to use GEOSpyD Min24.4.0 Python 3.12 stack
-  - NOTE: This requires using at least ESMA_cmake v3.45.1 due to f2py issues with Python 3.12. However, ESMA_env v5 should be used
+- Moved to use GEOSpyD Min24.4.0 Python 3.11 stack
+  - NOTE: This requires using at least ESMA_cmake v3.45.2 due to f2py issues with Python 3.12 testing. However, ESMA_env v5 should be used
     with ESMA_cmake v4.0.0 due to changes in the CMake build system to support FMS in Baselibs
 
 ## [5.0.0] - 2024-05-20

--- a/g5_modules
+++ b/g5_modules
@@ -131,7 +131,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
@@ -140,7 +140,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.12
-      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.12-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
@@ -166,7 +166,7 @@ else if ( $site == NAS ) then
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -191,7 +191,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/11.2.0
    set mod3 = comp/intel/2022.1.0
    set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+   set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh

--- a/g5_modules
+++ b/g5_modules
@@ -131,7 +131,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
@@ -140,7 +140,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.12
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.12-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
@@ -166,7 +166,7 @@ else if ( $site == NAS ) then
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -191,7 +191,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/11.2.0
    set mod3 = comp/intel/2022.1.0
    set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
This PR updates GEOS to use GEOSpyD Min24.4.0-0 which is Python 3.12.