### PR TITLE
Update to Baselibs 8.3.1, Intel ifort 2021.12 (save NCCS SLES12), and GEOSpyD 24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [5.1.0] - 2024-06-14
+## [5.1.0] - 2024-06-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [5.1.0] - 2024-06-11
+## [5.1.0] - 2024-06-14
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
-## [5.1.0] - 2024-06-21
+## [5.1.0] - 2024-07-05
 
 ### Changed
 
-- Update to Baselibs 8.1.0
+- Update to Baselibs 8.3.1
   - ESMF 8.6.1
-  - FMS 2024.01.01
+  - FMS 2024.01.02
   - curl 8.8.0
+  - NCO 5.2.6
+  - Various make system updates for other compilers and machines
 - Move to use Intel ifort 2021.12 on SLES 15 at NCCS, at NAS, and on GMAO Desktops
 - Update to GEOSpyD Min24.0.0 for Python3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.1.0] - 2024-06-11
+
+### Changed
+
+- Update to Baselibs 8.1.0
+  - ESMF 8.6.1
+  - FMS 2024.01.01
+  - curl 8.8.0
+- Move to use Intel ifort 2021.12 on SLES 15 at NCCS, at NAS, and on GMAO Desktops
+- Update to GEOSpyD Min24.0.0 for Python3
+
 ## [5.0.0] - 2024-05-20
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -191,7 +191,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/12.1.0
    set mod3 = comp/intel/2024.1-ifort
    set mod4 = mpi/impi/2021.12
-   set mod5 = other/python/GEOSpyD/Min24.1.2-0_py3.11
+   set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh

--- a/g5_modules
+++ b/g5_modules
@@ -132,7 +132,7 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
@@ -141,7 +141,7 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2024.1.0
       set mod4 = mpi/impi/2021.12
       set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12.0-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,7 +161,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
    set mod2 = comp-gcc/12.3.0-TOSS4
    set mod3 = comp-intel/2024.1.0-ifort
    set mod4 = mpi-hpe/mpt
@@ -184,7 +184,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12
 
    set mod1 = GEOSenv
 

--- a/g5_modules
+++ b/g5_modules
@@ -131,7 +131,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
@@ -140,7 +140,7 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2024.1.0
       set mod4 = mpi/impi/2021.12
-      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11
       set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
@@ -166,7 +166,7 @@ else if ( $site == NAS ) then
    set mod3 = comp-intel/2024.1.0-ifort
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -191,7 +191,7 @@ else if ( $site == GMAO.desktop ) then
    set mod2 = comp/gcc/12.1.0
    set mod3 = comp/intel/2024.1-ifort
    set mod4 = mpi/impi/2021.12
-   set mod5 = other/python/GEOSpyD/Min24.1.2-0_py3.12
+   set mod5 = other/python/GEOSpyD/Min24.1.2-0_py3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh

--- a/g5_modules
+++ b/g5_modules
@@ -131,17 +131,17 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
       set mod2 = comp/gcc/11.4.0
-      set mod3 = comp/intel/2021.6.0
+      set mod3 = comp/intel/2024.1.0
       set mod4 = mpi/impi/2021.12
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.12-SLES15
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,12 +161,12 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87
-   set mod2 = comp-gcc/11.2.0-TOSS4
-   set mod3 = comp-intel/2022.1.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
+   set mod2 = comp-gcc/12.3.0-TOSS4
+   set mod3 = comp-intel/2024.1.0-ifort
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.12_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -184,14 +184,14 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.0.2/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12
 
    set mod1 = GEOSenv
 
-   set mod2 = comp/gcc/11.2.0
-   set mod3 = comp/intel/2022.1.0
-   set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod2 = comp/gcc/12.1.0
+   set mod3 = comp/intel/2024.1-ifort
+   set mod4 = mpi/impi/2021.12
+   set mod5 = other/python/GEOSpyD/Min24.1.2-0_py3.12
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh

--- a/g5_modules
+++ b/g5_modules
@@ -161,7 +161,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.1.0/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
    set mod2 = comp-gcc/12.3.0-TOSS4
    set mod3 = comp-intel/2024.1.0-ifort
    set mod4 = mpi-hpe/mpt


### PR DESCRIPTION
This PR updates ESMA_env to:

- Update to Baselibs 8.3.1
  - ESMF 8.6.1
  - FMS 2024.01.02
  - curl 8.8.0
  - NCO 5.2.6
  - Various make system updates for other compilers and machines
- Move to use Intel ifort 2021.12 on SLES 15 at NCCS, at NAS, and on GMAO Desktops
- Update to GEOSpyD Min24.0.0 for Python3


NOTE: Because of the age of SLES12 at NCCS, we cannot move to 2021.12 there. So we stay at 2021.6. Testing so far shows 2021.12 on SLES15 is still zero-diff to 2021.6 but we have found bugs with 2021.6 that were fixed in newer versions.