### PR TITLE
Update to Baselibs 8.4.0, Intel 2021.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.2.0] - 2024-07-05
+
+### Changed
+
+- Update to Baselibs 8.4.0
+  - Restore FMS build (was erroneously removed in 8.2.0)
+  - Fixes for MPT and using icx/icpx at NAS
+- Move to use Intel ifort 2021.13 on SLES 15 at NCCS, at NAS, and on GMAO Desktops
+
 ## [5.1.0] - 2024-07-05
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -132,16 +132,16 @@ if ( $site == NCCS ) then
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.4.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
       set mod2 = comp/gcc/11.4.0
-      set mod3 = comp/intel/2024.1.0
-      set mod4 = mpi/impi/2021.12
+      set mod3 = comp/intel/2024.2.0
+      set mod4 = mpi/impi/2021.13
       set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12.0-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,9 +161,9 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-mpt_2.28_25Apr23_rhel87
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.28_25Apr23_rhel87
    set mod2 = comp-gcc/12.3.0-TOSS4
-   set mod3 = comp-intel/2024.1.0-ifort
+   set mod3 = comp-intel/2024.2.0-ifort
    set mod4 = mpi-hpe/mpt
 
    set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
@@ -184,13 +184,13 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.3.1/x86_64-pc-linux-gnu/ifort_2021.12.0-intelmpi_2021.12
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = GEOSenv
 
    set mod2 = comp/gcc/12.1.0
-   set mod3 = comp/intel/2024.1-ifort
-   set mod4 = mpi/impi/2021.12
+   set mod3 = comp/intel/2024.2-ifort
+   set mod4 = mpi/impi/2021.13
    set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )


### PR DESCRIPTION
Baselibs 8.3.1 had a bug in that FMS was not built. Baselibs 8.4.0 fixes this.

We also move to Intel 2021.13 as well.