### PR TITLE
Update to Baselibs 7.25.0, Intel 2021.13 and Intel MPI 2021.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.30.0] - 2024-07-22
+
+### Changed
+
+- Update to Baselibs 7.25.0
+  - ESMF v8.6.1
+  - GFE v1.16.0
+    - gFTL v1.14.0
+    - gFTL-shared v1.9.0
+    - fArgParse v1.8.0
+    - pFUnit v4.10.0
+    - yaFyaml v1.4.0
+  - curl 8.8.0
+  - NCO 5.2.6
+  - Other various fixes from the v8 branch
+- Move to use Intel ifort 2021.13 at NCCS SLES15, NAS, and GMAO Desktops
+- Move to use Intel MPI at NCCS SLES15 and GMAO Desktops
+- Move to GEOSpyD Min24.4.4 Python 3.11
+
+
 ## [4.29.0] - 2024-04-25
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -77,7 +77,7 @@ if (($node =~ discover*) || ($node =~ borg*)  || \
    # NCCS now has both SLES15 and SLES12 machines
    set OS_VERSION=`grep VERSION_ID /etc/os-release | cut -d= -f2 | cut -d. -f1 | sed 's/"//g'`
 
-else if (($node =~ pfe*) || ($node =~ tfe*) || \
+else if (($node =~ pfe*) || ($node =~ afe*) || \
          ($node =~ r[0-9]*i[0-9]*n[0-9]*) || \
          ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*)) then
 
@@ -131,17 +131,17 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.25.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
       set mod2 = comp/gcc/11.4.0
-      set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0-gcc-11.4.0
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
+      set mod3 = comp/intel/2024.2.0
+      set mod4 = mpi/impi/2021.13
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.25.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,12 +161,12 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87
-   set mod2 = comp-gcc/11.2.0-TOSS4
-   set mod3 = comp-intel/2022.1.0
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.25.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.28_25Apr23_rhel87
+   set mod2 = comp-gcc/12.3.0-TOSS4
+   set mod3 = comp-intel/2024.2.0-ifort
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -184,14 +184,14 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.25.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = GEOSenv
 
-   set mod2 = comp/gcc/11.2.0
-   set mod3 = comp/intel/2022.1.0
-   set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod2 = comp/gcc/12.1.0
+   set mod3 = comp/intel/2024.2-ifort
+   set mod4 = mpi/impi/2021.13
+   set mod5 = other/python/GEOSpyD/Min24.4.0-0_py3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
- Update to Baselibs 7.25.0
  - ESMF v8.6.1
  - GFE v1.16.0
    - gFTL v1.14.0
    - gFTL-shared v1.9.0
    - fArgParse v1.8.0
    - pFUnit v4.10.0
    - yaFyaml v1.4.0
  - curl 8.8.0
  - NCO 5.2.6
  - Other various fixes from the v8 branch
- Move to use Intel ifort 2021.13 at NCCS SLES15, NAS, and GMAO Desktops
- Move to use Intel MPI at NCCS SLES15 and GMAO Desktops
- Move to GEOSpyD Min24.4.4 Python 3.11