### PR TITLE
Update to Intel MPI 2021.13 (v4.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.25.2] - 2024-08-07
+
+### Changed
+
+- Move to Intel MPI 2021.13 at NCCS SLES15. Testing shows this is a more stable MPI stack on the system.
 
 ## [4.25.1] - 2024-01-24
 

--- a/g5_modules
+++ b/g5_modules
@@ -139,9 +139,9 @@ if ( $site == NCCS ) then
 
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
-      set mod4 = mpi/openmpi/4.1.6/intel-2021.6.0-gcc-11.4.0
+      set mod4 = mpi/impi/2021.13
       set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-openmpi_4.1.6-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.17.1/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif


### PR DESCRIPTION
This PR moves ESMA_env v4.25 to Intel MPI 2021.13. Testing of GEOS on the NCCS SLES15 nodes show that it seems to work more stably than Open MPI.