### PR TITLE
Fix order of operations with LD_LIBRARY_PATH and csh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.3.1] - 2024-09-09
+
+### Fixed
+
+- Fix issue between `g5_modules` and csh at NAS
+  - Changed order when setting `LD_LIBRARY_PATH` to avoid issues with csh and tclsh
+
 ## [5.3.0] - 2024-07-22
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -294,37 +294,6 @@ else
    exit 3
 endif
 
-# add BASEDIR lib to LD_LIBRARY_PATH, if not already there
-#---------------------------------------------------------
-
-if ($useldlibs) then
-   if ($?LD_LIBRARY_PATH) then
-      echo $LD_LIBRARY_PATH | grep $BASEDIR/$arch/lib > /dev/null
-      if ($status) then  #  == 1, if not found
-         setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/$arch/lib
-      endif
-   else
-      setenv LD_LIBRARY_PATH $BASEDIR/$arch/lib
-   endif
-
-# add individual $ld_libraries to LD_LIBRARY_PATH, if not already there
-#----------------------------------------------------------------------
-   if ($?ld_libraries) then
-      foreach lib ( $ld_libraries )
-         if ($LD_LIBRARY_PATH !~ *$lib*) then
-            setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$lib
-         endif
-      end
-   endif
-
-   if ($?LD_LIBRARY64_PATH) then
-      echo $LD_LIBRARY64_PATH | grep $BASEDIR/$arch/lib > /dev/null
-      if ($status) then  #  == 1, if not found
-         setenv LD_LIBRARY64_PATH ${LD_LIBRARY64_PATH}:$BASEDIR/$arch/lib
-      endif
-   endif
-endif
-
 # Set UDUNITS2_XML_PATH
 # ---------------------
 setenv UDUNITS2_XML_PATH $BASEDIR/$arch/share/udunits/udunits2.xml
@@ -356,6 +325,37 @@ if (-e $modinit) then
 
 endif
 if (! $wrapper) echo " for $node"
+
+# add BASEDIR lib to LD_LIBRARY_PATH, if not already there
+#---------------------------------------------------------
+
+if ($useldlibs) then
+   if ($?LD_LIBRARY_PATH) then
+      echo $LD_LIBRARY_PATH | grep $BASEDIR/$arch/lib > /dev/null
+      if ($status) then  #  == 1, if not found
+         setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/$arch/lib
+      endif
+   else
+      setenv LD_LIBRARY_PATH $BASEDIR/$arch/lib
+   endif
+
+# add individual $ld_libraries to LD_LIBRARY_PATH, if not already there
+#----------------------------------------------------------------------
+   if ($?ld_libraries) then
+      foreach lib ( $ld_libraries )
+         if ($LD_LIBRARY_PATH !~ *$lib*) then
+            setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$lib
+         endif
+      end
+   endif
+
+   if ($?LD_LIBRARY64_PATH) then
+      echo $LD_LIBRARY64_PATH | grep $BASEDIR/$arch/lib > /dev/null
+      if ($status) then  #  == 1, if not found
+         setenv LD_LIBRARY64_PATH ${LD_LIBRARY64_PATH}:$BASEDIR/$arch/lib
+      endif
+   endif
+endif
 
 # write sh commands to a .g5_modules.sh file
 #-------------------------------------------


### PR DESCRIPTION
Testing at NAS shows that for some reason, in 5.3.0, the order of operations on when you append the Baselibs `LD_LIBRARY_PATH` to the `LD_LIBRARY_PATH` in the csh shell can break TCL modules. So we reorder to load the modules first and then append to the `LD_LIBRARY_PATH`.