### PR TITLE
v4: Update default processor for build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.31.0] - 2024-09-13
+
+### Changed
+
+- Updated the default processors for `parallel_build.csh` to Milan at NCCS and Rome at NAS
+
 ## [4.30.1] - 2024-09-09
 
 ### Fixed

--- a/build.csh
+++ b/build.csh
@@ -308,7 +308,7 @@ if ($SITE == NCCS) then
    # as OpenMPI is only built for Infiniband
    if ($usegnu) then
       if ($nT == mil) then
-         echo "Using GNU at NCCS, setting queue to cas"
+         echo "Using GNU at NCCS, setting queue to mil"
          set proc = 'mil'
       else
          echo "Using GNU at NCCS, setting queue to cas"

--- a/build.csh
+++ b/build.csh
@@ -278,8 +278,8 @@ endif
 # default nodeTYPE
 #-----------------
 if (! $?nodeTYPE) then
-   if ($SITE == NCCS) set nodeTYPE = "Any"
-   if ($SITE == NAS)  set nodeTYPE = "Skylake"
+   if ($SITE == NCCS) set nodeTYPE = "Milan"
+   if ($SITE == NAS)  set nodeTYPE = "Rome"
 endif
 
 # at NCCS
@@ -336,11 +336,12 @@ endif
 if ( $SITE == NAS ) then
 
    set nT = `echo $nodeTYPE | cut -c1-3 | tr "[A-Z]" "[a-z]"`
-   if (($nT != has) && ($nT != bro) && ($nT != sky) && ($nT != cas) && ($nT != rom)) then
+   if (($nT != has) && ($nT != bro) && ($nT != sky) && ($nT != cas) && ($nT != rom) && ($nT != mil)) then
       echo "ERROR. Unknown node type at NAS: $nodeTYPE"
       exit 2
    endif
 
+   if ($nT == mil) set nT = 'mil_ait'
    if ($nT == rom) set nT = 'rom_ait'
    if ($nT == sky) set nT = 'sky_ele'
    if ($nT == cas) set nT = 'cas_ait'
@@ -351,6 +352,7 @@ if ( $SITE == NAS ) then
    if ($nT == sky_ele) @ NCPUS_DFLT = 40
    if ($nT == cas_ait) @ NCPUS_DFLT = 40
    if ($nT == rom_ait) @ NCPUS_DFLT = 128
+   if ($nT == mil_ait) @ NCPUS_DFLT = 128
 
    # TMPDIR needs to be reset
    #-------------------------
@@ -958,13 +960,13 @@ flagged options
    -account account     send batch job to account
    -walltime hh:mm:ss   time to use as batch walltime at job submittal
 
-   -mil                 compile on Milan nodes (only at NCCS)
-   -rom                 compile on Rome nodes (only at NAS)
+   -mil                 compile on Milan nodes (default at NCCS)
+   -rom                 compile on Rome nodes (default at NAS, only at NAS)
    -cas                 compile on Cascade Lake nodes
-   -sky                 compile on Skylake nodes (default at NAS)
+   -sky                 compile on Skylake nodes
    -bro                 compile on Broadwell nodes (only at NAS)
    -has                 compile on Haswell nodes (only at NAS)
-   -any                 compile on either Sky or Cascade Lake node (only at NCCS with SLURM, default at NCCS)
+   -any                 compile on either Sky or Cascade Lake node (only at NCCS)
 
 extra cmake options
 


### PR DESCRIPTION
This PR updates the default processors for `build.csh` (aka `parallel_build.csh`) to be:

* Milan (SLES15) at NCCS
* Rome at NAS