### PR TITLE
v4: Turn off useldlibs at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.31.1] - 2024-09-18
+
+### Fixed
+
+- Just do not append Baselibs `LD_LIBRARY_PATH` at NAS. Seems to break `parallel_build.csh`
+
 ## [4.31.0] - 2024-09-13
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -177,7 +177,7 @@ else if ( $site == NAS ) then
    set usemods = ( $usemod1 $usemod2 $usemod3 )
    set usemodules = 1
 
-   set useldlibs = 1
+   set useldlibs = 0
 
 #=================#
 #  GMAO DESKTOP   #


### PR DESCRIPTION
More testing at NAS found that appending Baselibs' `LD_LIBRARY_PATH` was breaking `parallel_build.csh`. So, like Bucy, we turn that off at NAS.