### PR TITLE
v5: Update to MPT 2.30 Baselibs at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.6.0] - 2025-01-06
+
+### Changed
+
+- Update to MPT 2.30 Baselibs at NAS. This is due to NAS updating the `mpi-hpe/mpt` module to `mpi-hpe/mpt.2.30`. While this does not break GEOS, CMake throws more errors due to differences in MPT that built Baselibs vs MPT that would build GEOS.
+
 ## [5.5.1] - 2024-11-06
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -161,7 +161,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.28_25Apr23_rhel87
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
    set mod2 = comp-gcc/12.3.0-TOSS4
    set mod3 = comp-intel/2024.2.0-ifort
    set mod4 = mpi-hpe/mpt


### PR DESCRIPTION
This PR updates to MPT 2.30 Baselibs at NAS. This is due to NAS updating the `mpi-hpe/mpt` module to `mpi-hpe/mpt.2.30`. While this does not break GEOS, CMake throws more errors due to differences in MPT that built Baselibs vs MPT that would build GEOS.