### PR TITLE
v4.29: Update to MPT 2.30 Baselibs at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.29.2] - 2025-01-06
+
+### Changed
+
+- Update to MPT 2.30 Baselibs at NAS. This is due to NAS updating the `mpi-hpe/mpt` module to `mpi-hpe/mpt.2.30`. While this does not break GEOS, CMake throws more errors due to differences in MPT that built Baselibs vs MPT that would build GEOS.
+
 ## [4.29.1] - 2024-10-16
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -131,8 +131,8 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.2.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.27.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
@@ -140,8 +140,8 @@ if ( $site == NCCS ) then
       set mod2 = comp/gcc/11.4.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.13
-      set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
+      set mod5 = python/GEOSpyD/24.3.0-0/3.11
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.27.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.13.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,12 +161,12 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.28_25Apr23_rhel87
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.27.0/x86_64-pc-linux-gnu/ifort_2022.1.0-mpt_2.30
    set mod2 = comp-gcc/11.2.0-TOSS4
    set mod3 = comp-intel/2022.1.0
    set mod4 = mpi-hpe/mpt
 
-   set mod5 = python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = python/GEOSpyD/24.3.0-0/3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/modules/init/tcsh
@@ -177,21 +177,21 @@ else if ( $site == NAS ) then
    set usemods = ( $usemod1 $usemod2 $usemod3 )
    set usemodules = 1
 
-   set useldlibs = 1
+   set useldlibs = 0
 
 #=================#
 #  GMAO DESKTOP   #
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.24.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.27.0/x86_64-pc-linux-gnu/ifort_2022.1.0-intelmpi_2022.1.0
 
    set mod1 = GEOSenv
 
    set mod2 = comp/gcc/11.2.0
    set mod3 = comp/intel/2022.1.0
    set mod4 = mpi/impi/2022.1.0
-   set mod5 = other/python/GEOSpyD/Min23.5.2-0_py3.11_AND_Min4.8.3_py2.7
+   set mod5 = other/python/GEOSpyD/24.3.0-0/3.11
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 )
    set modinit = /usr/share/Modules/init/tcsh


### PR DESCRIPTION
This PR updates to MPT 2.30 Baselibs at NAS. This is due to NAS updating the `mpi-hpe/mpt` module to `mpi-hpe/mpt.2.30`. While this does not break GEOS, CMake throws more errors due to differences in MPT that built Baselibs vs MPT that would build GEOS.