### PR TITLE
v5: Update to Baselibs 8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.7.0] - 2025-01-16
+
+### Changed
+
+- Update to Baselibs 8.9.0
+  - ESMF 8.8.0
+  - NCO 5.3.1
+  - CDO 2.5.0
+  - curl 8.11.1
+- Add support for flang-new
+- Turn off ESMPy building. It's not working and maybe we don't want to
+  build from source anyway as it's easier through mamba
+
 ## [5.6.0] - 2025-01-06
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -128,20 +128,20 @@ if ( $site == NCCS ) then
 
    if ( $OS_VERSION == 12 ) then
 
-      set mod2 = comp/gcc/11.2.0
+      set mod2 = comp/gcc/12.1.0
       set mod3 = comp/intel/2021.6.0
       set mod4 = mpi/impi/2021.6.0
       set mod5 = python/GEOSpyD/Min24.4.0-0_py3.11_AND_Min4.8.3_py2.7
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.9.0/x86_64-pc-linux-gnu/ifort_2021.6.0-intelmpi_2021.6.0-SLES12
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES12
 
    else
 
-      set mod2 = comp/gcc/11.4.0
+      set mod2 = comp/gcc/12.3.0
       set mod3 = comp/intel/2024.2.0
       set mod4 = mpi/impi/2021.13
       set mod5 = python/GEOSpyD/24.3.0-0/3.11
-      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15
+      set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.9.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15
       set usemod1 = /discover/swdev/gmao_SIteam/modulefiles-SLES15
 
    endif
@@ -161,7 +161,7 @@ else if ( $site == NAS ) then
 
    set mod1 = GEOSenv
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.9.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
    set mod2 = comp-gcc/12.3.0-TOSS4
    set mod3 = comp-intel/2024.2.0-ifort
    set mod4 = mpi-hpe/mpt
@@ -184,7 +184,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.7.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir=/ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.9.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = GEOSenv
 


### PR DESCRIPTION
This updates v5 to use Baselibs 8.9.0 which provides ESMF 8.8.0 (needed by MAPL3)