### PR TITLE
v4: Update Baselibs to 7.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [4.37.0] - 2025-04-24
+
+### Changed
+
+- Update to Baselibs 7.33.0
+  - ESMF 8.8.1
+  - NCO 5.3.3
+  - CDO 2.5.1
+  - Fixes for CMake 4.0
+
 ## [4.36.0] - 2025-03-18
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -121,7 +121,7 @@ set useldlibs = 0
 #========#
 if ( $site == NCCS ) then
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0-SLES15
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-7.33.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -144,7 +144,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-7.33.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -169,10 +169,11 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-7.33.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = other/python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
+
    set mod3 = comp/gcc/12.1.0
    set mod4 = comp/intel/2024.2-ifort
    set mod5 = mpi/impi/2021.13


### PR DESCRIPTION
This PR updates v4 to use Baselibs 7.33.0 which has ESMF 8.8.1 (needed for MAPL3 work) as well as updates to NCO and CDO. It also has CMake 4 build support.