### PR TITLE
v4: Cache ENVIRONMENT_MODULES variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
+- Make the `ENVIRONMENT_MODULES` variable a `CACHE` variable
+
 ### Fixed
 ### Removed
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (EnvModules_FOUND)
 else ()
    set (ENVIRONMENT_MODULES "No environment modules were found")
 endif ()
+set(ENVIRONMENT_MODULES "${ENVIRONMENT_MODULES}" CACHE INTERNAL "List of environment modules")
 
 foreach (conf_file BASEDIR.rc SITE.rc CMAKE_VERSION.rc GIT_VERSION.rc BUILD_MODULES.rc)
    configure_file(${conf_file}.in ${conf_file} @ONLY)


### PR DESCRIPTION
This PR caches `ENVIRONMENT_MODULES` to capture it in https://github.com/GEOS-ESM/GEOSgcm/pull/930