### PR TITLE
v5: Update to Baselibs 8.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.13.0] - 2025-08-27
+
+### Changed
+
+- Update to Baselibs 8.18.0
+  - ESMF 8.9.0
+  - curl 8.15.0
+  - NCO 5.3.4
+  - CDO 2.5.3
+  - nccmp 1.10.0.0
+  - *Removed* szip, *added* libaec
+    - Note: To use libaec correctly, users should use `ESMA_cmake` v3.63.0/v4.20.0 or higher
+
+### Fixed
+
+- Added `afe` support at NAS in `build.csh`
+- Added restriction that using `-mil` at NAS cannot be asked for on `pfe` nodes
+
 ## [5.12.0] - 2025-05-13
 
 ### Changed
@@ -22,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to Baselibs 7.33.0
+- Update to Baselibs 8.14.0
   - ESMF 8.8.1
   - NCO 5.3.3
   - CDO 2.5.1
@@ -48,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update to Baselibs 7.32.0
+- Update to Baselibs 8.13.0
   - GFE v1.19.0
     - gFTL v1.15.2
     - gFTL-shared v1.10.0

--- a/build.csh
+++ b/build.csh
@@ -52,7 +52,7 @@ if ( ($node == dirac)   \
    setenv SITE NCCS
 
 else if (($node =~ pfe*)   \
-      || ($node =~ tfe*)   \
+      || ($node =~ afe*)   \
       || ($node =~ r[0-9]*i[0-9]*n[0-9]*) \
       || ($node =~ r[0-9]*c[0-9]*t[0-9]*n[0-9]*)) then
    setenv SITE NAS
@@ -332,6 +332,12 @@ if ( $SITE == NAS ) then
    set nT = `echo $nodeTYPE | cut -c1-3 | tr "[A-Z]" "[a-z]"`
    if (($nT != has) && ($nT != bro) && ($nT != sky) && ($nT != cas) && ($nT != rom) && ($nT != mil)) then
       echo "ERROR. Unknown node type at NAS: $nodeTYPE"
+      exit 2
+   endif
+
+   # At NAS, you cannot submit to Milan nodes from pfe nodes
+   if ( ($nT == mil) && ($node =~ pfe*) ) then
+      echo "ERROR. Milan nodes cannot be accessed from pfe nodes. Please use afe nodes."
       exit 2
    endif
 
@@ -913,7 +919,7 @@ flagged options
    -account account     send batch job to account
    -walltime hh:mm:ss   time to use as batch walltime at job submittal
 
-   -mil                 compile on Milan nodes (default at NCCS)
+   -mil                 compile on Milan nodes (default at NCCS; at NAS must be submitted from afe nodes)
    -rom                 compile on Rome nodes (default at NAS, only at NAS)
    -cas                 compile on Cascade Lake nodes
    -sky                 compile on Skylake nodes (only at NAS)

--- a/g5_modules
+++ b/g5_modules
@@ -121,7 +121,7 @@ set useldlibs = 0
 #========#
 if ( $site == NCCS ) then
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.14.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -145,7 +145,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.14.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -170,7 +170,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.14.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = other/python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv


### PR DESCRIPTION
This PR updates ESMA_env to use Baselibs 8.18.0 which has:

  - ESMF 8.9.0
  - curl 8.15.0
  - NCO 5.3.4
  - CDO 2.5.3
  - nccmp 1.10.0.0
  - *Removed* szip, *added* libaec
    - Note: To use libaec correctly, users should use `ESMA_cmake` v3.63.0/v4.20.0 or higher

Testing shows Baselibs 8.18.0 is zero-diff.

We also tweak `build.csh` so that users at NAS selecting `-mil` need to be on an `afe` node.