### PR TITLE
Update to Baselibs 8.19.0 (esmf v9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.14.0] - 2025-09-19
+
+### Changed
+
+- Update to Baselibs 8.19.0
+  - esmf 9.0.0b03
+  - curl 8.16.0
+  - Fixed issue with CDO and flang to disable the Fortran interface (see https://code.mpimet.mpg.de/boards/1/topics/16399)
+  - Turn off `SDPToolkit` build with flang
+
 ## [5.13.0] - 2025-08-27
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -121,7 +121,7 @@ set useldlibs = 0
 #========#
 if ( $site == NCCS ) then
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.19.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -145,7 +145,7 @@ if ( $site == NCCS ) then
 #=======#
 else if ( $site == NAS ) then
 
-   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+   set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.19.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
 
    set mod1 = python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv
@@ -170,7 +170,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.18.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.19.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = other/python/GEOSpyD/24.11.3-0/3.12
    set mod2 = GEOSenv


### PR DESCRIPTION
This PR updates ESMA_env to Baselibs 8.19.0 which as ESMF v9.0.0b03.

Note: To use this with GEOS requires MAPL 2.59.1 or 2.61 as there is a needed workaround for a (deprecated) `ESMF_AttributeGet` call in MAPL. 