### PR TITLE
v6: Update to Baselibs 9.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [6.3.0] - 2026-03-18
+
+### Changed
+
+- Update to Baselibs 8.27.0
+  - ESMF v9.0.0b10
+  - GFE v1.23.0
+    - gFTL v1.17.0
+    - gFTL-shared v1.12.0
+    - fArgParse v1.11.0
+    - pFUnit v4.16.0
+  - Better support for LLVM Flang
+
 ## [6.2.0] - 2026-02-10
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -130,7 +130,7 @@ set useldlibs = 0
 #========#
 if ( $site == NCCS ) then
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-9.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-9.7.1/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mod1 = python/GEOSpyD/25.3.1-0/3.13
    set mod2 = GEOSenv
@@ -158,7 +158,7 @@ else if ( $site == NAS ) then
 
    if ( $TOSS_VERSION == "TOSS4" ) then
 
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-9.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-9.7.1/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
 
       set mod1 = python/GEOSpyD/25.3.1-0/3.13
       set mod2 = GEOSenv
@@ -180,7 +180,7 @@ else if ( $site == NAS ) then
 
    else
 
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-9.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-craympich_8.1.33
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-9.7.1/x86_64-pc-linux-gnu/ifort_2021.13.0-craympich_8.1.33
 
       set mod1 = python/GEOSpyD/25.3.1-0/3.13
       set mod2 = GEOSenv
@@ -211,7 +211,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-9.4.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-9.7.1/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = other/python/GEOSpyD/25.3.1-0/3.13
    set mod2 = GEOSenv


### PR DESCRIPTION
This PR updates to use Baselibs 9.7.1 which has updates for ESMF and GFE.

Zero-diff for GEOSgcm