### PR TITLE
v5: Add sensible build defaults at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.20.0] - 2026-03-25
+
+### Changed
+
+- Update `build.csh` to set default NAS node type based on login node
+  - `pfe*` → Rome (`rom_ait`)
+  - `afe*` → Milan (`mil_ait`)
+  - `athfe*` → Turin (`tur_ath`)
+
 ## [5.19.1] - 2026-03-19
 
 ### Fixed

--- a/build.csh
+++ b/build.csh
@@ -27,6 +27,8 @@
 # 10Oct2017  MAT     Added Skylake at NAS. Added option to pass in
 #                    account
 # 08Jul2019  MAT     Changes for git-based GEOSadas
+# 25Mar2026  MAT     Default NAS node type now based on login node
+#                    (pfe->Rome, afe->Milan, athfe->Turin)
 #------------------------------------------------------------------------
 
 # NOTE: This is now called by a stub routine. For sanity's
@@ -289,7 +291,19 @@ endif
 #-----------------
 if (! $?nodeTYPE) then
    if ($SITE == NCCS) set nodeTYPE = "Milan"
-   if ($SITE == NAS)  set nodeTYPE = "Rome"
+   if ($SITE == NAS) then
+      # Default node type depends on which NAS login node we are on:
+      #   pfe*   --> Rome  (rom_ait)
+      #   afe*   --> Milan (mil_ait)
+      #   athfe* --> Turin (tur_ath)
+      if ($node =~ athfe*) then
+         set nodeTYPE = "Turin"
+      else if ($node =~ afe*) then
+         set nodeTYPE = "Milan"
+      else
+         set nodeTYPE = "Rome"
+      endif
+   endif
 endif
 
 # at NCCS
@@ -944,11 +958,16 @@ flagged options
 
    -tur                 compile on Turin nodes (only at NAS, must be submitted from athfe nodes)
    -mil                 compile on Milan nodes (default at NCCS; at NAS must be submitted from afe nodes)
-   -rom                 compile on Rome nodes (default at NAS, only at NAS)
+   -rom                 compile on Rome nodes (only at NAS)
    -cas                 compile on Cascade Lake nodes
    -sky                 compile on Skylake nodes (only at NAS)
    -bro                 compile on Broadwell nodes (only at NAS)
    -any                 compile on any node (only at NCCS)
+
+   Default NAS node type is based on login node:
+      pfe*   -> Rome  (-rom)
+      afe*   -> Milan (-mil)
+      athfe* -> Turin (-tur)
 
 extra cmake options
 


### PR DESCRIPTION
This PR adds "sensible" defaults at NAS depending on the login node a user submits from:

- `pfe*` → Rome (`rom_ait`)
- `afe*` → Milan (`mil_ait`)
- `athfe*` → Turin (`tur_ath`)