### PR TITLE
[DSL] Introduce `USE_DSL` to pull in `DSL/latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+- `USE_DSL` environement variable pilot a swap from the regular`GEOSpyD` python to the `DSL/latest` one
+
 ## [6.4.0] - 2026-03-25
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -132,7 +132,12 @@ if ( $site == NCCS ) then
 
    set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-9.7.1/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
-   set mod1 = python/GEOSpyD/25.3.1-0/3.13
+   if ($?USE_DSL) then
+      set mod1 = DSL/latest
+   else
+      set mod1 = python/GEOSpyD/25.3.1-0/3.13
+   endif
+   
    set mod2 = GEOSenv
 
    set mod3 = comp/gcc/12.3.0


### PR DESCRIPTION
This PR relies on the `USE_DSL` environment variable to load the experimental DSL package in lieu of the GEOSPyD default python package.

Future work will endeavor to merge those.

Related PR: https://github.com/GEOS-ESM/GEOSgcm_App/pull/826