### PR TITLE
v5: Default to normal queue for Turin nodes at NAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.20.1] - 2026-03-26
+
+### Fixed
+
+- Update `build.csh` to default to `-q normal` for Turin nodes, which require at least the normal queue
+
 ## [5.20.0] - 2026-03-25
 
 ### Changed

--- a/build.csh
+++ b/build.csh
@@ -386,6 +386,9 @@ if ( $SITE == NAS ) then
    if ($nT == mil_ait) @ NCPUS_DFLT = 128
    if ($nT == tur_ath) @ NCPUS_DFLT = 256
 
+   # Turin requires at least the normal queue
+   if (($nT == tur_ath) && ("$queue" == "")) set queue = "-q normal"
+
    # TMPDIR needs to be reset
    #-------------------------
    if ($tmpdir == '') then


### PR DESCRIPTION
## Summary

- Turin nodes at NAS require at least the `normal` queue to run
- Update `build.csh` to default to `-q normal` when the node type is `tur_ath` and no queue has been specified
- Bump version to 5.20.1 in `CHANGELOG.md`