### PR TITLE
v5: Update GEOSpyD and ISSM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.23.0] - 2026-05-28
+
+### Changed
+
+- Move to GEOSpyD 26.3.2 Python 3.14
+- Updated ISSM module to geos/1.0.2-py3.14
+
 ## [5.22.0] - 2026-05-05
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -135,9 +135,9 @@ if ( $site == NCCS ) then
    if ($?USE_DSL) then
       set mod1 = DSL/latest
    else
-      set mod1 = python/GEOSpyD/25.3.1-0/3.13
+      set mod1 = python/GEOSpyD/26.3.2-0/3.14
    endif
-   
+
    set mod2 = GEOSenv
 
    set mod3 = comp/gcc/12.3.0
@@ -145,7 +145,7 @@ if ( $site == NCCS ) then
    set mod5 = mpi/impi/2021.13
    set mod6 = other/jemalloc/5.3.0
 
-   set mod7 = other/ISSM/geos/1.0.0/ifort_2021.13.0-intelmpi_2021.13.0
+   set mod7 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
    set modinit = /usr/share/modules/init/csh
@@ -165,14 +165,14 @@ else if ( $site == NAS ) then
 
       set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
 
-      set mod1 = python/GEOSpyD/25.3.1-0/3.13
+      set mod1 = python/GEOSpyD/26.3.2-0/3.14
       set mod2 = GEOSenv
 
       set mod3 = comp-gcc/12.3.0-TOSS4
       set mod4 = comp-intel/2024.2.0-ifort
       set mod5 = mpi-hpe/mpt
 
-      set mod6 = other/ISSM/geos/1.0.0/ifort_2021.13.0-mpt_2.30
+      set mod6 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-mpt_2.30
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
       set modinit = /usr/share/modules/init/tcsh
@@ -187,7 +187,7 @@ else if ( $site == NAS ) then
 
       set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-craympich_8.1.33
 
-      set mod1 = python/GEOSpyD/25.3.1-0/3.13
+      set mod1 = python/GEOSpyD/26.3.2-0/3.14
       set mod2 = GEOSenv
 
       set mod3 = comp-gcc/12.5.0
@@ -195,7 +195,7 @@ else if ( $site == NAS ) then
       set mod5 = comp-intel/2024.2.0
       set mod6 = mpi/mpich-ifort
 
-      set mod7 = other/ISSM/geos/1.0.0/ifort_2021.13.0-craympich_8.1.33
+      set mod7 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-craympich_8.1.33
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
       set modinit = /opt/cray/pe/modules/3.2.11.7/init/csh
@@ -218,7 +218,7 @@ else if ( $site == GMAO.desktop ) then
 
    set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
-   set mod1 = other/python/GEOSpyD/25.3.1-0/3.13
+   set mod1 = other/python/GEOSpyD/26.3.2-0/3.14
    set mod2 = GEOSenv
 
    set mod3 = comp/gcc/12.1.0


### PR DESCRIPTION
This pull request updates the environment modules used for various supported sites to newer versions of Python and ISSM. The main changes are the upgrade to GEOSpyD 26.3.2 with Python 3.14 and the update of the ISSM module to geos/1.0.2-py3.14 across all relevant environments.

**Module version upgrades:**

* Updated all references to the `GEOSpyD` Python environment from version `25.3.1-0/3.13` to `26.3.2-0/3.14` in the `g5_modules` script for the `NCCS`, `NAS`, and `GMAO.desktop` sites. [[1]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L138-R138) [[2]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L168-R175) [[3]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L190-R198) [[4]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L221-R221)
* Updated all references to the `ISSM` module from `geos/1.0.0` to `geos/1.0.2-py3.14` in the `g5_modules` script for the `NCCS` and `NAS` sites. [[1]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L148-R148) [[2]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L168-R175) [[3]](diffhunk://#diff-b5015084dccbe5cac15b3d00f714a6f0b21e69ceca133338ca4c7b3abbdca339L190-R198)

Tests show this is zero-diff.