### PR TITLE
v5: Update to Baselibs 8.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.24.0] - 2026-06-04
+
+### Changed
+
+- Update to Baselibs 8.32.0
+  - GFE v1.28.0
+    - pFUnit v4.19.0
+    - pFlogger v1.18.1
+  - fftw v3.3.11
+  - Various fixes for compiler testing
+
 ## [5.23.0] - 2026-05-28
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -130,14 +130,13 @@ set useldlibs = 0
 #========#
 if ( $site == NCCS ) then
 
-   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
+   set basedir = /discover/swdev/gmao_SIteam/Baselibs/ESMA-Baselibs-8.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13.0
 
    if ($?USE_DSL) then
       set mod1 = DSL/latest
    else
       set mod1 = python/GEOSpyD/26.3.2-0/3.14
    endif
-
    set mod2 = GEOSenv
 
    set mod3 = comp/gcc/12.3.0
@@ -163,16 +162,16 @@ else if ( $site == NAS ) then
 
    if ( $TOSS_VERSION == "TOSS4" ) then
 
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-mpt_2.30
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
       set mod1 = python/GEOSpyD/26.3.2-0/3.14
       set mod2 = GEOSenv
 
       set mod3 = comp-gcc/12.3.0-TOSS4
       set mod4 = comp-intel/2024.2.0-ifort
-      set mod5 = mpi-hpe/mpt
+      set mod5 = mpi-impi/2021.13
 
-      set mod6 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-mpt_2.30
+      set mod6 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-intelmpi_2021.13
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
       set modinit = /usr/share/modules/init/tcsh
@@ -185,12 +184,12 @@ else if ( $site == NAS ) then
 
    else
 
-      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-craympich_8.1.33
+      set basedir = /nobackup/gmao_SIteam/Baselibs/ESMA-Baselibs-8.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-craympich_8.1.33
 
       set mod1 = python/GEOSpyD/26.3.2-0/3.14
       set mod2 = GEOSenv
 
-      set mod3 = comp-gcc/12.5.0
+      set mod3 = comp-gcc/12.5.0-rebuild
       set mod4 = PrgEnv-intel/8.6.0
       set mod5 = comp-intel/2024.2.0
       set mod6 = mpi/mpich-ifort
@@ -216,7 +215,7 @@ else if ( $site == NAS ) then
 #=================#
 else if ( $site == GMAO.desktop ) then
 
-   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.27.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
+   set basedir = /ford1/share/gmao_SIteam/Baselibs/ESMA-Baselibs-8.32.0/x86_64-pc-linux-gnu/ifort_2021.13.0-intelmpi_2021.13
 
    set mod1 = other/python/GEOSpyD/26.3.2-0/3.14
    set mod2 = GEOSenv


### PR DESCRIPTION
This PR updates ESMA_env to use Baselibs 8.32.0. This has updates to GFE as well as adding fftw for LDAS work.

Tests show this is zero-diff.