### PR TITLE
v5: Update to ISSM geos/1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.25.0] - 2026-07-07
+
+### Changed
+
+- Update ISSM module to geos/1.0.3
+
 ## [5.24.0] - 2026-06-04
 
 ### Changed

--- a/g5_modules
+++ b/g5_modules
@@ -144,7 +144,7 @@ if ( $site == NCCS ) then
    set mod5 = mpi/impi/2021.13
    set mod6 = other/jemalloc/5.3.0
 
-   set mod7 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-intelmpi_2021.13.0
+   set mod7 = other/ISSM/geos/1.0.3/ifort_2021.13.0-intelmpi_2021.13.0
 
    set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
    set modinit = /usr/share/modules/init/csh
@@ -171,7 +171,7 @@ else if ( $site == NAS ) then
       set mod4 = comp-intel/2024.2.0-ifort
       set mod5 = mpi-impi/2021.13
 
-      set mod6 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-intelmpi_2021.13
+      set mod6 = other/ISSM/geos/1.0.3/ifort_2021.13.0-intelmpi_2021.13
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 )
       set modinit = /usr/share/modules/init/tcsh
@@ -194,7 +194,7 @@ else if ( $site == NAS ) then
       set mod5 = comp-intel/2024.2.0
       set mod6 = mpi/mpich-ifort
 
-      set mod7 = other/ISSM/geos/1.0.2-py3.14/ifort_2021.13.0-craympich_8.1.33
+      set mod7 = other/ISSM/geos/1.0.3/ifort_2021.13.0-craympich_8.1.33
 
       set mods = ( $mod1 $mod2 $mod3 $mod4 $mod5 $mod6 $mod7 )
       set modinit = /opt/cray/pe/modules/3.2.11.7/init/csh


### PR DESCRIPTION
This PR updates the ISSM module to geos/1.0.3

Keeping draft until all modules built at NAS and NCCS