### PR TITLE
Support module switching in g5_modules.sh/zsh for v5.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.25.1] - 2026-08-11
+
+### Fixed
+
+- Support module switching in `g5_modules.sh` and `g5_modules.zsh` based on `switchmodules` output from `g5_modules`
+
 ## [5.25.0] - 2026-07-07
 
 ### Changed

--- a/g5_modules.sh
+++ b/g5_modules.sh
@@ -40,3 +40,12 @@ for mymod in $(csh $g5modules modules); do
     module load $mymod
 done
 
+for switchmod in $(csh $g5modules switchmodules); do
+    if [ "$switchmod" != "0" ]; then
+        frommodule=${switchmod%%:*}
+        tomodule=${switchmod#*:}
+        module switch $frommodule $tomodule
+    fi
+done
+
+

--- a/g5_modules.zsh
+++ b/g5_modules.zsh
@@ -40,3 +40,12 @@ for mymod in $(csh $g5modules modules); do
     module load $mymod
 done
 
+for switchmod in $(csh $g5modules switchmodules); do
+    if [ "$switchmod" != "0" ]; then
+        frommodule=${switchmod%%:*}
+        tomodule=${switchmod#*:}
+        module switch $frommodule $tomodule
+    fi
+done
+
+


### PR DESCRIPTION
## Description
Adds support for module switching in `g5_modules.sh` and `g5_modules.zsh` based on the output of `csh g5_modules switchmodules`.

Updates `CHANGELOG.md` for patch release 5.25.1.