### PR TITLE
Fix undefined variable error in g5_modules for v5.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Added
 
+## [5.25.2] - 2026-08-11
+
+### Fixed
+
+- Check variable existence before echoing in `g5_modules` to prevent undefined variable errors when `switchmodules` or `usemodules` is queried
+
 ## [5.25.1] - 2026-08-11
 
 ### Fixed

--- a/g5_modules
+++ b/g5_modules
@@ -277,16 +277,28 @@ if ( $#argv > 0 ) then
       echo $modinit
 
    else if ( $1 == usemodules ) then
-      echo $usemods
+      if ( $?usemods ) then
+         echo $usemods
+      else
+         echo 0
+      endif
 
    else if ( $1 == switchmodules ) then
-      echo $switchmods
+      if ( $?switchmods ) then
+         echo $switchmods
+      else
+         echo 0
+      endif
 
    else if ( $1 == useldlibs ) then
       echo $useldlibs
 
    else if ( $1 == ESMA_FC ) then
-      echo $ESMA_FC
+      if ( $?ESMA_FC ) then
+         echo $ESMA_FC
+      else
+         echo 0
+      endif
 
    else if ( $1 == site ) then
       echo $site


### PR DESCRIPTION
## Description
Fixes `switchmods: Undefined variable.` error when running `csh g5_modules switchmodules` on systems where `switchmods` is not defined.

Updates `CHANGELOG.md` for patch release 5.25.2.